### PR TITLE
docs: AbstractionKit v0.3.0 release post and unpin SDK versions

### DIFF
--- a/blog/2026-04-14-abstractionkit-v0-3-0-release/index.md
+++ b/blog/2026-04-14-abstractionkit-v0-3-0-release/index.md
@@ -17,7 +17,7 @@ Safe Unified Account is audited by Nethermind. Calibur joins `Simple7702Account`
 
 ## Safe Unified Account, audited
 
-Safe Unified Account is now audited by Nethermind. If you were waiting for the audit before building on it, this is the release. We [first shipped it in February](./safe-unified-account).
+Safe Unified Account is now audited by Nethermind. If you were waiting for the audit before building on it, this is the release. We [first shipped it in February](/blog/safe-unified-account).
 
 The API is unchanged. Sign once, execute anywhere. Key rotations, guardian updates, account configuration: one signing session covers every chain. Each leaf in the Merkle tree is a UserOperation hash. You sign the root, each chain receives the signature plus a Merkle proof, and verification happens independently onchain. No relayers. No bridges.
 
@@ -72,7 +72,7 @@ userOperation.signature = smartAccount.signUserOperation(
 
 ## Parallelizable paymaster signing
 
-We [announced EntryPoint v0.9 support in February](./entrypoint-v09-support) through the Voltaire Bundler and `Simple7702AccountV09`. This release wires the new v0.9 paymaster flow into `CandidePaymaster` so apps can use it end to end.
+We [announced EntryPoint v0.9 support in February](/blog/entrypoint-v09-support) through the Voltaire Bundler and `Simple7702AccountV09`. This release wires the new v0.9 paymaster flow into `CandidePaymaster` so apps can use it end to end.
 
 Why it matters: under v0.8, the paymaster had to sign **before** the user, because the paymaster signature was part of what the user was signing over. That meant a paymaster round trip sitting between "user taps send" and the wallet's confirmation UI. On v0.9, a dedicated `paymasterSignature` field lets the paymaster sign **after** the user. The paymaster round trip can run in parallel with the user signing ceremony, and the confirmation UI shows up sooner.
 

--- a/blog/2026-04-14-abstractionkit-v0-3-0-release/index.md
+++ b/blog/2026-04-14-abstractionkit-v0-3-0-release/index.md
@@ -1,0 +1,110 @@
+---
+slug: abstractionkit-v0-3-0-release
+title: "AbstractionKit v0.3.0"
+description: SafeMultiChainSigAccountV1 is audited by Nethermind. Calibur joins Simple7702Account as a second EIP-7702 option. CandidePaymaster adds parallelizable signing on EntryPoint v0.9, cutting latency between tap and confirmation.
+image: "/img/posters/abstractionkit-meta.png"
+authors: [marc]
+tags: [sdk, chain-abstraction, eip-7702, entrypoint-v09]
+---
+
+# AbstractionKit v0.3.0
+
+![abstractionkit_poster](/img/posters/abstractionkit-poster.png)
+
+Safe Unified Account is audited by Nethermind. Calibur joins `Simple7702Account` as a second EIP-7702 account design. And `CandidePaymaster` now does parallelizable paymaster signing on EntryPoint v0.9.
+
+<!-- truncate -->
+
+## Safe Unified Account, audited
+
+Safe Unified Account is now audited by Nethermind. If you were waiting for the audit before building on it, this is the release. We [first shipped it in February](./safe-unified-account).
+
+The API is unchanged. Sign once, execute anywhere. Key rotations, guardian updates, account configuration: one signing session covers every chain. Each leaf in the Merkle tree is a UserOperation hash. You sign the root, each chain receives the signature plus a Merkle proof, and verification happens independently onchain. No relayers. No bridges.
+
+```typescript
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit"
+
+const signatures = smartAccount.signUserOperations(
+  [
+    { userOperation: userOp1, chainId: chainId1 },
+    { userOperation: userOp2, chainId: chainId2 },
+  ],
+  [ownerPrivateKey],
+)
+```
+
+**Breaking change:** `ExperimentalSafeMultiChainSigAccount` is now `SafeMultiChainSigAccountV1`. Update imports.
+
+[Chain Abstraction quickstart](/wallet/guides/chain-abstraction-getting-started/) · [SDK reference](/wallet/abstractionkit/safe-unified-account)
+
+## Calibur: EIP-7702 with real key management
+
+Calibur is the EIP-7702 account built by the Uniswap team for the Uniswap Wallet. It is audited by Cantina and OpenZeppelin. We added support because Calibur is one of the few EIP-7702 implementations designed for EOA upgrades from the ground up, not retrofitted from an existing account.
+
+It complements `Simple7702Account`. Reach for Simple when you want batching and sponsorship on top of an EOA with minimal surface area. Reach for Calibur when you want real key management: passkeys, multikey, per-key hooks, revocable delegation.
+
+What you get:
+- Same address after delegation. No migration.
+- Batching and gas sponsorship on EntryPoint v0.8.
+- Passkey authentication via the EIP-7951 P256 precompile.
+- Multikey management with per-key hooks. Register, revoke, and configure keys directly on the account.
+- Delegation revocation via `createRevokeDelegationRawTransaction` if the user wants to return to a plain EOA.
+
+```typescript
+import { Calibur7702Account } from "abstractionkit"
+
+const smartAccount = new Calibur7702Account(eoaAddress)
+
+let userOperation = await smartAccount.createUserOperation(
+  [tx1, tx2],
+  nodeUrl,
+  bundlerUrl,
+)
+
+userOperation.signature = smartAccount.signUserOperation(
+  userOperation, privateKey, chainId
+)
+```
+
+`Calibur7702Account` auto-checks delegation state inside `createUserOperation`, so upgrading an EOA for the first time just works.
+
+[Calibur quickstart](/wallet/guides/getting-started-calibur/) · [SDK reference](/wallet/abstractionkit/calibur-account)
+
+## Parallelizable paymaster signing
+
+We [announced EntryPoint v0.9 support in February](./entrypoint-v09-support) through the Voltaire Bundler and `Simple7702AccountV09`. This release wires the new v0.9 paymaster flow into `CandidePaymaster` so apps can use it end to end.
+
+Why it matters: under v0.8, the paymaster had to sign **before** the user, because the paymaster signature was part of what the user was signing over. That meant a paymaster round trip sitting between "user taps send" and the wallet's confirmation UI. On v0.9, a dedicated `paymasterSignature` field lets the paymaster sign **after** the user. The paymaster round trip can run in parallel with the user signing ceremony, and the confirmation UI shows up sooner.
+
+`CandidePaymaster` exposes this through a two-phase `signingPhase` context. **Commit** requests sponsorship before the user signs. **Finalize** attaches the paymaster signature afterwards:
+
+```typescript
+const commitOverrides   = { context: { signingPhase: "commit"   as const } }
+const finalizeOverrides = { context: { signingPhase: "finalize" as const } }
+```
+
+`CandidePaymaster` is unified around `pm_getPaymasterData` and is [ERC-7677](https://eips.ethereum.org/EIPS/eip-7677) compliant. Any wallet or dapp that speaks the Paymaster Web Service Capability standard can talk to it directly. Token paymaster flows run on v0.9, and `Simple7702AccountV09` supports the two-phase flow alongside Safe Unified Account. AbstractionKit continues to support v0.7 and v0.8 in the same build.
+
+## Also in this release
+
+- **Delegation introspection.** `getDelegatedAddress` and `isDelegated` let you check EIP-7702 delegation state before sending a UserOperation.
+- **Safe Allowance Module v1.0.0.** The v0.1.0 address is kept as a legacy constant for migrations.
+- **USDT-safe approvals.** SafeAccount multisend now prepends `approve(0)` for ERC-20s that require an allowance reset, so batched approvals no longer silently revert.
+- **Agent skill for Safe Unified Account.** A single markdown file a coding agent can read to integrate the account end to end:
+  ```bash
+  claude "Read https://docs.candide.dev/safe-unified-account-agent-skill.md and integrate the Safe Unified Account"
+  ```
+
+A reminder worth repeating: AbstractionKit does not lock your app into a specific web3 library, node provider, bundler, or paymaster. Use viem or ethers, your own RPC, any ERC-4337 bundler, and any ERC-7677 paymaster. No vendor lock-in.
+
+## Start building
+
+Safe Unified Account is audited. Calibur is in the SDK. `CandidePaymaster` is faster. Pick whichever fits what you're building.
+
+If you run into something or want to talk through a design, find us on [Discord](https://discord.gg/8q2H6BEJuf).
+
+## Resources
+
+- [Examples repo](https://github.com/candidelabs/abstractionkit-examples)
+- [AbstractionKit on GitHub](https://github.com/candidelabs/abstractionkit)
+- [Documentation](https://docs.candide.dev/wallet/abstractionkit/introduction/)

--- a/docs/wallet/abstractionkit/12-calibur-account.mdx
+++ b/docs/wallet/abstractionkit/12-calibur-account.mdx
@@ -133,10 +133,10 @@ Before using `Calibur7702Account`, you must have:
 ### Installation
 
 ```bash
-npm install abstractionkit@0.2.39
+npm install abstractionkit
 ```
 
-Calibur support requires abstractionkit v0.2.39 or later. The contracts are audited by OpenZeppelin and Cantina.
+The contracts are audited by OpenZeppelin and Cantina.
 
 ### Usage
 

--- a/docs/wallet/abstractionkit/9-simple-7702-account.mdx
+++ b/docs/wallet/abstractionkit/9-simple-7702-account.mdx
@@ -63,7 +63,7 @@ export const GETTING_STARTED_ITEMS = [
     },
     {
         title: "Simple 7702 Account for EP v0.9",
-        description: "Reference functions for Simple 7702 Account with EntryPoint v0.9. Paymaster not yet supported.",
+        description: "Reference functions for Simple 7702 Account with EntryPoint v0.9. Supports gas sponsorship and ERC-20 gas payments.",
         route: "/wallet/abstractionkit/simple-7702-account-v09",
     },
 ];

--- a/docs/wallet/guides/10-getting-started-calibur.mdx
+++ b/docs/wallet/guides/10-getting-started-calibur.mdx
@@ -31,7 +31,7 @@ npx tsc --init
 
 ```bash
 npm i typescript --save-dev
-npm i abstractionkit@0.2.39 dotenv
+npm i abstractionkit dotenv
 ```
 
 3. Configure Environment Variables

--- a/docs/wallet/guides/11-calibur-passkeys.mdx
+++ b/docs/wallet/guides/11-calibur-passkeys.mdx
@@ -31,7 +31,7 @@ Here's the [complete code](https://github.com/candidelabs/abstractionkit-example
 1. Install dependencies:
 
 ```bash
-npm i abstractionkit@0.2.39 dotenv
+npm i abstractionkit dotenv
 ```
 
 2. Configure environment variables. Create a `.env` file:

--- a/docs/wallet/guides/12-calibur-key-management.mdx
+++ b/docs/wallet/guides/12-calibur-key-management.mdx
@@ -29,7 +29,7 @@ Here's the [complete code](https://github.com/candidelabs/abstractionkit-example
 1. Install dependencies:
 
 ```bash
-npm i abstractionkit@0.2.39 dotenv
+npm i abstractionkit dotenv
 ```
 
 2. Configure environment variables. Create a `.env` file:

--- a/docs/wallet/guides/6-getting-started-eip-7702.mdx
+++ b/docs/wallet/guides/6-getting-started-eip-7702.mdx
@@ -38,7 +38,7 @@ npx tsc --init
 
 ```bash
 npm i typescript --save-dev
-npm i abstractionkit@0.2.39 dotenv ethers
+npm i abstractionkit dotenv ethers
 ```
 
 3. Configure Environment Variables

--- a/docs/wallet/guides/chain-abstraction-getting-started.md
+++ b/docs/wallet/guides/chain-abstraction-getting-started.md
@@ -55,7 +55,7 @@ npx tsc --init
 
 ```bash
 npm install typescript ts-node --save-dev
-npm install abstractionkit@0.2.41 dotenv viem
+npm install abstractionkit dotenv viem
 ```
 
 **What each package does:**

--- a/docs/wallet/plugins/4-allowance-migration.mdx
+++ b/docs/wallet/plugins/4-allowance-migration.mdx
@@ -16,7 +16,7 @@ The new contract address is `0x691f59471Bfd2B7d639DCF74671a2d648ED1E331`, replac
 No special steps. Install the latest version of AbstractionKit and use the default constructor:
 
 ```bash title="terminal"
-npm install abstractionkit@0.2.39
+npm install abstractionkit
 ```
 
 ```ts

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -158,9 +158,9 @@ const config = {
       },
       image: 'img/posters/atelier-meta.png',
       announcementBar: {
-        id: 'chain-abstraction',
+        id: 'abstractionkit-v0-3-0',
         content:
-          'Chain Abstraction: Sign once, execute on every chain. Multichain signatures for Safe, now audited. <a href="/wallet/guides/chain-abstraction-overview/">Learn more</a>',
+          'AbstractionKit v0.3.0 is out: Safe Unified Account audited, Calibur Account, and parallelizable paymaster signing. <a href="/blog/abstractionkit-v0-3-0-release">Read the release</a>',
         backgroundColor: '#fce7f0',
         textColor: '#1a1a1a',
         isCloseable: true,


### PR DESCRIPTION
## Summary

- Adds the AbstractionKit v0.3.0 release blog post covering the audited Safe Unified Account, Calibur Account (EIP-7702), and parallelizable paymaster signing on EntryPoint v0.9
- Unpins \`abstractionkit@0.2.x\` from install snippets across the docs (8 files) so readers always pull the latest
- Removes the stale "Paymaster not yet supported" note from the Simple7702 EntryPoint v0.9 card

## Notes for reviewers

- Version in the post title and slug is \`v0.3.0\`. Current \`package.json\` in the SDK repo is \`0.2.41\`. Confirm the version bump before merging or adjust the slug/title.
- Calibur audit attribution reads "Cantina and OpenZeppelin" throughout. Worth a quick check against the Uniswap audit reports.
- Discord link uses the canonical invite from \`docusaurus.config.js\`.
- No changes to the Feb 19 Safe Unified Account post. It still carries the original "early release / unaudited" framing as historical context. Tell me if you want a banner or rewrite.

## Test plan

- [ ] \`yarn start\` and confirm the new blog post renders with the poster image and \`<!-- truncate -->\` preview
- [ ] Confirm all unpinned install snippets still resolve correctly on a fresh \`npm install\`
- [ ] Verify the updated Simple7702 v0.9 card copy reads correctly in the SDK reference sidebar
- [ ] Check that the linked prior posts (\`./safe-unified-account\`, \`./entrypoint-v09-support\`) resolve via Docusaurus blog routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)