### PR TITLE
docs: sync AbstractionKit docs with v0.3.1 and v0.3.2

### DIFF
--- a/docs/wallet/abstractionkit/10-simple-7702-account-v09.mdx
+++ b/docs/wallet/abstractionkit/10-simple-7702-account-v09.mdx
@@ -178,6 +178,25 @@ userOperation.signature = signature;
 
 </Tabs>
 
+### signUserOperationWithSigner
+
+Signs a UserOperation using an [`ExternalSigner`](/wallet/guides/authentication#external-signers) instead of a raw private key. Integrates viem, ethers, hardware wallets, HSMs, and MPC services through the same API. Simple7702 requires a signer that implements `signHash` (raw 32-byte hash).
+
+```ts title="example.ts"
+import { fromViem } from "abstractionkit";
+import { privateKeyToAccount } from "viem/accounts";
+
+const viemAccount = privateKeyToAccount("0x...");
+
+userOperation.signature = await smartAccount.signUserOperationWithSigner(
+  userOperation,
+  fromViem(viemAccount),
+  11155111n, // chain ID
+);
+```
+
+See [External Signers](/wallet/guides/authentication#external-signers) for the full list of adapters and custom-signer integrations. EntryPoint v0.9 also supports parallel paymaster signing via the two-phase `signingPhase` context — see the [v0.9 external-signer example](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/06-external-signer-v09.ts).
+
 ### sendUserOperation
 
 Sends a signed UserOperation to the bundler for execution on-chain.

--- a/docs/wallet/abstractionkit/11-simple-7702-account-v08.mdx
+++ b/docs/wallet/abstractionkit/11-simple-7702-account-v08.mdx
@@ -178,6 +178,25 @@ userOperation.signature = signature;
 
 </Tabs>
 
+### signUserOperationWithSigner
+
+Signs a UserOperation using an [`ExternalSigner`](/wallet/guides/authentication#external-signers) instead of a raw private key. Integrates viem, ethers, hardware wallets, HSMs, and MPC services through the same API. Simple7702 requires a signer that implements `signHash` (raw 32-byte hash).
+
+```ts title="example.ts"
+import { fromViem } from "abstractionkit";
+import { privateKeyToAccount } from "viem/accounts";
+
+const viemAccount = privateKeyToAccount("0x...");
+
+userOperation.signature = await smartAccount.signUserOperationWithSigner(
+  userOperation,
+  fromViem(viemAccount),
+  11155111n, // chain ID
+);
+```
+
+See [External Signers](/wallet/guides/authentication#external-signers) for the full list of adapters and custom-signer integrations.
+
 ### sendUserOperation
 
 Sends a signed UserOperation to the bundler for execution on-chain.

--- a/docs/wallet/abstractionkit/12-calibur-account.mdx
+++ b/docs/wallet/abstractionkit/12-calibur-account.mdx
@@ -255,31 +255,36 @@ userOperation.signature = smartAccount.signUserOperation(
 
 ### signUserOperationWithSigner
 
-Signs a UserOperation with an external signer (viem, ethers Signer, hardware wallet, MPC signer, etc.). Computes the UserOperation hash and wraps the returned signature in Calibur's format. By default signs with the root key.
+Signs a UserOperation using an [`ExternalSigner`](/wallet/guides/authentication#external-signers) instead of a raw private key. Integrates viem, ethers, hardware wallets, HSMs, MPC, and WebAuthn through the same API. By default signs with the root key; pass `{ keyHash }` to sign with a registered secondary key.
+
+Calibur requires a signer that implements `signHash` (raw 32-byte hash, no EIP-191 prefix). Signers that only expose `signTypedData` (e.g. a viem `WalletClient` via `fromViemWalletClient`) fail offline with an actionable error.
 
 <Tabs>
 <TabItem value="example.ts" label="example.ts">
 
 ```ts title="example.ts"
+import { fromViem } from "abstractionkit";
 import { privateKeyToAccount } from "viem/accounts";
 
 const viemAccount = privateKeyToAccount("0x...private-key");
 
-// Sign with a viem account
+// Sign with the root key
 userOperation.signature = await smartAccount.signUserOperationWithSigner(
   userOperation,
-  async (hash) => viemAccount.sign({ hash: hash as `0x${string}` }),
-  11155111n // chain ID
+  fromViem(viemAccount),
+  11155111n, // chain ID
 );
 
-// Sign with a secondary key using a viem account
+// Sign with a registered secondary key
 userOperation.signature = await smartAccount.signUserOperationWithSigner(
   userOperation,
-  async (hash) => viemAccount.sign({ hash: hash as `0x${string}` }),
+  fromViem(viemAccount),
   11155111n,
-  { keyHash: "0x...registered-key-hash" }
+  { keyHash: "0x...registered-key-hash" },
 );
 ```
+
+See [External Signers](/wallet/guides/authentication#external-signers) for the full list of adapters (viem, ethers, custom) and the [Calibur external-signer example](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/calibur-account/04-external-signer.ts) for a full end-to-end flow.
 
 </TabItem>
 

--- a/docs/wallet/abstractionkit/13-safe-unified-account.mdx
+++ b/docs/wallet/abstractionkit/13-safe-unified-account.mdx
@@ -182,6 +182,33 @@ userOp2.signature = signatures[1];
 
 [signUserOperations](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeMultiChainSigAccount.ts)
 
+### signUserOperationsWithSigners
+
+Multi-op variant that signs a Merkle-rooted bundle of UserOperations using one or more [`ExternalSigner`s](/wallet/guides/authentication#external-signers) instead of raw private keys. One signing session covers every chain in the bundle.
+
+The Merkle root has no typed-data display, so this path requires a signer that implements `signHash`. `fromViemWalletClient` (typed-data only) fails offline here; use `fromViem`, `fromEthersWallet`, or a custom signer.
+
+```ts title="example.ts"
+import { SafeMultiChainSigAccountV1 as SafeAccount, fromViem } from "abstractionkit";
+import { privateKeyToAccount } from "viem/accounts";
+
+const smartAccount = SafeAccount.initializeNewAccount([ownerPublicAddress]);
+const viemAccount = privateKeyToAccount("0x...");
+
+const signatures = await smartAccount.signUserOperationsWithSigners(
+    [
+        { userOperation: userOp1, chainId: 11155111n },
+        { userOperation: userOp2, chainId: 11155420n },
+    ],
+    [fromViem(viemAccount)],
+);
+
+userOp1.signature = signatures[0];
+userOp2.signature = signatures[1];
+```
+
+See [External Signers](/wallet/guides/authentication#external-signers) for the full list of adapters, and the [multi-chain add-owner example](https://github.com/candidelabs/abstractionkit-examples/blob/main/chain-abstraction/add-owner-with-external-signer.ts) for a full end-to-end flow.
+
 ### getMultiChainSingleSignatureUserOperationsEip712Hash
 
 Static method. Computes the EIP-712 hash of the Merkle tree root for a set of UserOperations. This is the hash that wallet signers (browser extensions, hardware wallets) sign to approve multiple cross-chain operations at once.
@@ -268,7 +295,9 @@ import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
 
 const userOpsToSign = [
     { userOperation: userOp1, chainId: 11155111n },
-    { userOperation: userOp2, chainId: 11155420n },
+    // Per-operation overrides (e.g. WebAuthn verifier addresses) go on the
+    // op itself — the previous third `overrides` argument was removed in v0.3.1.
+    { userOperation: userOp2, chainId: 11155420n, overrides: { /* ... */ } },
 ];
 
 const signerSignaturePairs = [

--- a/docs/wallet/abstractionkit/3.paymaster.mdx
+++ b/docs/wallet/abstractionkit/3.paymaster.mdx
@@ -562,3 +562,60 @@ const exchangeRate = await paymaster.fetchTokenPaymasterExchangeRate(erc20TokenA
 
 #### Source code
 [createPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/main/src/paymaster/CandidePaymaster.ts#L508)
+
+## Erc7677Paymaster
+
+`Erc7677Paymaster` is a provider-agnostic [ERC-7677](https://eips.ethereum.org/EIPS/eip-7677) paymaster client. It speaks `pm_getPaymasterStubData` and `pm_getPaymasterData`, so it works with any compliant provider (Candide, Pimlico, Alchemy, or a self-hosted paymaster). Provider is auto-detected from the RPC URL; for Candide and Pimlico it also fetches exchange rates and paymaster addresses automatically for ERC-20 token flows.
+
+If you are using Candide's paymaster and want features like parallel signing phases, prefer [`CandidePaymaster`](#paymaster) above. Use `Erc7677Paymaster` when you want a single client that can switch providers without code changes.
+
+### Usage
+
+#### Import
+
+```ts
+import { Erc7677Paymaster } from "abstractionkit";
+```
+
+#### Sponsored UserOperation
+
+```ts title="example.ts"
+import { Erc7677Paymaster } from "abstractionkit";
+
+const paymaster = new Erc7677Paymaster("https://api.candide.dev/public/v3/sepolia");
+
+// Use createUserOperation() to help you construct a userOp
+let userOperation = await smartAccount.createUserOperation(/* ... */);
+
+userOperation = await paymaster.createPaymasterUserOperation(
+  smartAccount,
+  userOperation,
+  bundlerRpc,
+  { sponsorshipPolicyId: "sp_..." }, // provider-specific context
+);
+```
+
+#### ERC-20 token sponsorship
+
+Passing `{ token }` in the context triggers the ERC-20 gas flow automatically. For Candide and Pimlico the exchange rate is fetched for you; for unknown providers, supply `exchangeRate` in the context.
+
+```ts title="example.ts"
+// Candide or Pimlico (auto-detected): exchange rate fetched from the RPC
+userOperation = await paymaster.createPaymasterUserOperation(
+  smartAccount,
+  userOperation,
+  bundlerRpc,
+  { token: usdcAddress },
+);
+
+// Unknown provider: supply exchangeRate (scaled by 1e18)
+userOperation = await paymaster.createPaymasterUserOperation(
+  smartAccount,
+  userOperation,
+  bundlerRpc,
+  { token: usdcAddress, exchangeRate: "1000000000000000000" },
+);
+```
+
+#### Source code
+[Erc7677Paymaster](https://github.com/candidelabs/abstractionkit/blob/main/src/paymaster/Erc7677Paymaster.ts)

--- a/docs/wallet/abstractionkit/3.paymaster.mdx
+++ b/docs/wallet/abstractionkit/3.paymaster.mdx
@@ -582,7 +582,8 @@ import { Erc7677Paymaster } from "abstractionkit";
 ```ts title="example.ts"
 import { Erc7677Paymaster } from "abstractionkit";
 
-const paymaster = new Erc7677Paymaster("https://api.candide.dev/public/v3/sepolia");
+const bundlerRpc = "https://api.candide.dev/public/v3/sepolia";
+const paymaster = new Erc7677Paymaster(bundlerRpc);
 
 // Use createUserOperation() to help you construct a userOp
 let userOperation = await smartAccount.createUserOperation(/* ... */);
@@ -600,6 +601,9 @@ userOperation = await paymaster.createPaymasterUserOperation(
 Passing `{ token }` in the context triggers the ERC-20 gas flow automatically. For Candide and Pimlico the exchange rate is fetched for you; for unknown providers, supply `exchangeRate` in the context.
 
 ```ts title="example.ts"
+const bundlerRpc = "https://api.candide.dev/public/v3/sepolia";
+const usdcAddress = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"; // USDC on sepolia
+
 // Candide or Pimlico (auto-detected): exchange rate fetched from the RPC
 userOperation = await paymaster.createPaymasterUserOperation(
   smartAccount,

--- a/docs/wallet/abstractionkit/7-safe-account-v2.mdx
+++ b/docs/wallet/abstractionkit/7-safe-account-v2.mdx
@@ -347,6 +347,25 @@ console.log(signature);
 ```
 </details>
 
+### signUserOperationWithSigners
+
+Signs a UserOperation using one or more [`ExternalSigner`s](/wallet/guides/authentication#external-signers) instead of raw private keys. Integrates viem, ethers, hardware wallets, HSMs, MPC services, and WebAuthn through the same API.
+
+```ts title="example.ts"
+import { fromEthersWallet } from "abstractionkit";
+import { Wallet } from "ethers";
+
+const wallet = new Wallet("0x...");
+
+userOperation.signature = await smartAccount.signUserOperationWithSigners(
+  userOperation,
+  [fromEthersWallet(wallet)],
+  chainId,
+);
+```
+
+See [External Signers](/wallet/guides/authentication#external-signers) for the full list of adapters and custom-signer integrations.
+
 #### Source code
 [signUserOperation](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_2_0.ts#L479)
 

--- a/docs/wallet/abstractionkit/7-safe-account-v2.mdx
+++ b/docs/wallet/abstractionkit/7-safe-account-v2.mdx
@@ -347,6 +347,9 @@ console.log(signature);
 ```
 </details>
 
+#### Source code
+[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_2_0.ts#L479)
+
 ### signUserOperationWithSigners
 
 Signs a UserOperation using one or more [`ExternalSigner`s](/wallet/guides/authentication#external-signers) instead of raw private keys. Integrates viem, ethers, hardware wallets, HSMs, MPC services, and WebAuthn through the same API.
@@ -367,7 +370,7 @@ userOperation.signature = await smartAccount.signUserOperationWithSigners(
 See [External Signers](/wallet/guides/authentication#external-signers) for the full list of adapters and custom-signer integrations.
 
 #### Source code
-[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_2_0.ts#L479)
+[signUserOperationWithSigners](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccount.ts)
 
 ### sendUserOperation
 

--- a/docs/wallet/abstractionkit/8-safe-account-v3.mdx
+++ b/docs/wallet/abstractionkit/8-safe-account-v3.mdx
@@ -342,6 +342,9 @@ userOperation.signature = await smartAccount.signUserOperationWithSigners(
 
 See [External Signers](/wallet/guides/authentication#external-signers) for the full list of adapters and custom-signer integrations.
 
+#### Source code
+[signUserOperationWithSigners](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccount.ts)
+
 ### sendUserOperation
 
 This method sends the UserOperation to the bundler to be executed on-chain. It returns a promise `SendUseroperationResponse` object to confirm the on-chain inclusion of the UserOperation.

--- a/docs/wallet/abstractionkit/8-safe-account-v3.mdx
+++ b/docs/wallet/abstractionkit/8-safe-account-v3.mdx
@@ -323,6 +323,25 @@ console.log(signature);
 #### Source code
 [signUserOperation](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_3_0.ts#L383)
 
+### signUserOperationWithSigners
+
+Signs a UserOperation using one or more [`ExternalSigner`s](/wallet/guides/authentication#external-signers) instead of raw private keys. Integrates viem, ethers, hardware wallets, HSMs, MPC services, and WebAuthn through the same API.
+
+```ts title="example.ts"
+import { fromViem } from "abstractionkit";
+import { privateKeyToAccount } from "viem/accounts";
+
+const viemAccount = privateKeyToAccount("0x...");
+
+userOperation.signature = await smartAccount.signUserOperationWithSigners(
+  userOperation,
+  [fromViem(viemAccount)],
+  chainId,
+);
+```
+
+See [External Signers](/wallet/guides/authentication#external-signers) for the full list of adapters and custom-signer integrations.
+
 ### sendUserOperation
 
 This method sends the UserOperation to the bundler to be executed on-chain. It returns a promise `SendUseroperationResponse` object to confirm the on-chain inclusion of the UserOperation.

--- a/docs/wallet/guides/10-getting-started-calibur.mdx
+++ b/docs/wallet/guides/10-getting-started-calibur.mdx
@@ -197,10 +197,11 @@ userOperation.signature = smartAccount.signUserOperation(
     chainId,
 );
 
-// Option B: Use a viem signer callback
+// Option B: Use a viem account via fromViem adapter
+// import { fromViem } from "abstractionkit";
 // userOperation.signature = await smartAccount.signUserOperationWithSigner(
 //     userOperation,
-//     async (hash) => viemAccount.sign({ hash: hash as `0x${string}` }),
+//     fromViem(viemAccount),
 //     chainId,
 // );
 ```

--- a/docs/wallet/guides/5-authentication.mdx
+++ b/docs/wallet/guides/5-authentication.mdx
@@ -105,14 +105,13 @@ const smartAccount = SafeAccount.initializeNewAccount([signerAddress]);
 
 #### Signing a UserOperation
 
-The recommended path for every new integration is the capability-oriented **[External Signer](#external-signers)** API. One `signUserOperationWithSigner(s)` call works across viem, ethers, hardware wallets, HSMs, MPC, and WebAuthn signers, without handing private keys to the SDK.
+The recommended path for every new integration is the capability-oriented **[External Signer](#external-signers)** API. `signUserOperationWithSigner(s)` returns an account-ready signature: hash computation and signature formatting are handled for you across viem, ethers, hardware wallets, HSMs, MPC, and WebAuthn signers, without handing private keys to the SDK.
 
 The manual EIP-712 flow below is kept for advanced use cases where you need direct control over hash computation or signature formatting.
 
 ##### Manual EIP-712 signing (advanced)
 
-Regardless of the approach you choose, you must format the resulting signature into a `userOperation`
-compatible signature using [`formatEip712SignaturesToUserOperationSignature()`](../../abstractionkit/safe-account-v3/#formateip712signaturestouseroperationsignature).
+Only this manual flow requires formatting the raw signature yourself. Regardless of which of the two approaches below you choose, you must wrap the resulting signature into a `userOperation`-compatible signature using [`formatEip712SignaturesToUserOperationSignature()`](../../abstractionkit/safe-account-v3/#formateip712signaturestouseroperationsignature). The External Signer API above does this automatically.
 
 1. **Direct Signing of the EIP-712 Hash**
 
@@ -251,16 +250,21 @@ const signatures = await account.signUserOperationsWithSigners(
 
 ### Pick an adapter
 
-AbstractionKit ships four built-in adapters. Each wraps a concrete signer type into an `ExternalSigner` in one line.
+AbstractionKit ships three built-in adapters and supports custom `ExternalSigner` implementations. Each adapter wraps a concrete signer type into an `ExternalSigner` in one line.
+
+**Built-in adapters**
 
 | Adapter | For | Example |
 |---|---|---|
 | `fromViem(localAccount)` | any viem `LocalAccount` (`privateKeyToAccount`, `toAccount`, wagmi connector accounts) | [fromViem.ts](https://github.com/candidelabs/abstractionkit-examples/blob/main/signer/fromViem.ts) |
 | `fromEthersWallet(wallet)` | any ethers `Wallet` or `HDNodeWallet` (ethers >= 6) | [fromEthersWallet.ts](https://github.com/candidelabs/abstractionkit-examples/blob/main/signer/fromEthersWallet.ts) |
 | `fromViemWalletClient(client)` | viem `WalletClient` (browser / injected wallet, typed-data only) | [fromViemWalletClient.ts](https://github.com/candidelabs/abstractionkit-examples/blob/main/signer/fromViemWalletClient.ts) |
-| Custom `ExternalSigner` | HSM, MPC, hardware wallet, `Uint8Array`-held keys, WebAuthn | [customSigner.ts](https://github.com/candidelabs/abstractionkit-examples/blob/main/signer/customSigner.ts) |
 
 Each example in the repo is self-contained. If you use viem, read `fromViem.ts`; if you use ethers, read `fromEthersWallet.ts`. You do not need to install both libraries to use AbstractionKit.
+
+**Custom / extensible**
+
+For HSMs, MPC services, hardware wallets, `Uint8Array`-held keys, or WebAuthn, implement the `ExternalSigner` interface directly: see [customSigner.ts](https://github.com/candidelabs/abstractionkit-examples/blob/main/signer/customSigner.ts) for a reference implementation.
 
 :::tip Raw private keys
 For a single-owner private-key setup, the legacy sync API is the shortest path and needs no adapter:

--- a/docs/wallet/guides/5-authentication.mdx
+++ b/docs/wallet/guides/5-authentication.mdx
@@ -103,9 +103,14 @@ const smartAccount = SafeAccount.initializeNewAccount([signerAddress]);
 </TabItem>
 </Tabs>
 
-#### Signing a UserOperation with EIP-712
+#### Signing a UserOperation
 
-When signing a `userOperation` using `abstractionkit`, you have two options based on your use case. 
+The recommended path for every new integration is the capability-oriented **[External Signer](#external-signers)** API. One `signUserOperationWithSigner(s)` call works across viem, ethers, hardware wallets, HSMs, MPC, and WebAuthn signers, without handing private keys to the SDK.
+
+The manual EIP-712 flow below is kept for advanced use cases where you need direct control over hash computation or signature formatting.
+
+##### Manual EIP-712 signing (advanced)
+
 Regardless of the approach you choose, you must format the resulting signature into a `userOperation`
 compatible signature using [`formatEip712SignaturesToUserOperationSignature()`](../../abstractionkit/safe-account-v3/#formateip712signaturestouseroperationsignature).
 
@@ -223,3 +228,81 @@ userOperation.signature = smartAccount.signUserOperation(
   chainId,
 )
 ```
+
+## External Signers
+
+Available since AbstractionKit v0.3.2. `ExternalSigner` is a capability-oriented interface that lets you plug any signing source into AbstractionKit without passing raw private keys to the SDK. It covers viem local accounts, viem WalletClients, ethers Wallets, hardware wallets, HSMs, MPC services, and WebAuthn signers through a single API.
+
+Every account class exposes the same method family:
+
+```ts
+// Safe accounts — multi-signer (plural)
+userOperation.signature = await safe.signUserOperationWithSigners(userOperation, [signer], chainId)
+
+// Simple7702 / Calibur — single signer
+userOperation.signature = await account.signUserOperationWithSigner(userOperation, signer, chainId)
+
+// SafeMultiChainSigAccountV1 — multi-op, one signature across chains
+const signatures = await account.signUserOperationsWithSigners(
+  [{ userOperation: op1, chainId: id1 }, { userOperation: op2, chainId: id2 }],
+  [signer],
+)
+```
+
+### Pick an adapter
+
+AbstractionKit ships four built-in adapters. Each wraps a concrete signer type into an `ExternalSigner` in one line.
+
+| Adapter | For | Example |
+|---|---|---|
+| `fromViem(localAccount)` | any viem `LocalAccount` (`privateKeyToAccount`, `toAccount`, wagmi connector accounts) | [fromViem.ts](https://github.com/candidelabs/abstractionkit-examples/blob/main/signer/fromViem.ts) |
+| `fromEthersWallet(wallet)` | any ethers `Wallet` or `HDNodeWallet` (ethers >= 6) | [fromEthersWallet.ts](https://github.com/candidelabs/abstractionkit-examples/blob/main/signer/fromEthersWallet.ts) |
+| `fromViemWalletClient(client)` | viem `WalletClient` (browser / injected wallet, typed-data only) | [fromViemWalletClient.ts](https://github.com/candidelabs/abstractionkit-examples/blob/main/signer/fromViemWalletClient.ts) |
+| Custom `ExternalSigner` | HSM, MPC, hardware wallet, `Uint8Array`-held keys, WebAuthn | [customSigner.ts](https://github.com/candidelabs/abstractionkit-examples/blob/main/signer/customSigner.ts) |
+
+Each example in the repo is self-contained. If you use viem, read `fromViem.ts`; if you use ethers, read `fromEthersWallet.ts`. You do not need to install both libraries to use AbstractionKit.
+
+:::tip Raw private keys
+For a single-owner private-key setup, the legacy sync API is the shortest path and needs no adapter:
+
+```ts
+userOperation.signature = smartAccount.signUserOperation(userOperation, [privateKey], chainId)
+```
+
+`fromPrivateKey(pk)` also exists when you want every owner (pk, HSM, hardware wallet) to flow through the same async interface in a multi-owner setup.
+:::
+
+### Shape
+
+```ts
+type ExternalSigner = { address: `0x${string}` } & (
+  | { signHash:       (hash: `0x${string}`) => Promise<`0x${string}`>
+      signTypedData?: (data: TypedData)     => Promise<`0x${string}`> }
+  | { signHash?:      (hash: `0x${string}`) => Promise<`0x${string}`>
+      signTypedData:  (data: TypedData)     => Promise<`0x${string}`> }
+)
+```
+
+The discriminated union enforces at compile time that every signer implements at least one of `signHash` or `signTypedData`. Canonical definition in [`src/signer/types.ts`](https://github.com/candidelabs/abstractionkit/blob/main/src/signer/types.ts), re-exported from the package root as `ExternalSigner`.
+
+### Capability negotiation
+
+Each account class declares which signing schemes it accepts:
+
+| Account | Accepted schemes | Notes |
+|---|---|---|
+| Safe (V0.2.0, V0.3.0, V1.5.0) | `typedData`, `hash` | Prefers `typedData` for structured EIP-712 display in wallet UIs |
+| `SafeMultiChainSigAccountV1` (single-op) | `typedData`, `hash` | Same preference as Safe |
+| `SafeMultiChainSigAccountV1` (multi-op Merkle path) | `hash` only | The Merkle root has no typed-data display |
+| `Simple7702Account`, `Simple7702AccountV09`, `Calibur7702Account` | `hash` only | Raw 32-byte hash, no EIP-191 prefix |
+
+When a signer exposes both capabilities the account picks the preferred scheme. Capability mismatches throw **offline** with an actionable error: a `fromViemWalletClient` signer (typed-data only) passed to Calibur or to the multi-op Merkle path fails before any wallet prompt is triggered.
+
+### Account-specific flows
+
+Full end-to-end scripts in the examples repo:
+
+- [Simple7702 (EntryPoint v0.8)](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/05-external-signer.ts)
+- [Simple7702 (EntryPoint v0.9, two-phase paymaster)](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/06-external-signer-v09.ts)
+- [Calibur](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/calibur-account/04-external-signer.ts)
+- [Safe Unified Account: multi-chain add-owner with one signature](https://github.com/candidelabs/abstractionkit-examples/blob/main/chain-abstraction/add-owner-with-external-signer.ts)

--- a/docs/wallet/guides/onchain-identifiers.mdx
+++ b/docs/wallet/guides/onchain-identifiers.mdx
@@ -68,7 +68,19 @@ Aggregate:
 
 ### Fuzzy match: `handleOps` tx input
 
-The bundler wraps the userOp in `EntryPoint.handleOps(ops[], beneficiary)`. The marker ends up inside the tx `input`, not at the tail, because a trailing beneficiary address sits after it. Use substring (not suffix) match:
+The bundler wraps userOps in `EntryPoint.handleOps(ops[], beneficiary)`. The ABI-encoded tx calldata is laid out as:
+
+```text
+selector (4 bytes)
+│
+├─ head
+│    offset-to-ops  (32 bytes)
+│    beneficiary    (32 bytes)
+│
+└─ ops data (dynamic: length + each op, with callData inlined as dynamic bytes)
+```
+
+The marker is inside each op's `callData`, so it appears somewhere in the dynamic tail of the tx input, not strictly at the end. With multiple userOps batched into one `handleOps` call, each op's callData contributes its own marker occurrence at a different offset. Suffix matching on `tx.input` is not reliable. Use substring match, or decode the ops array and inspect each `callData`:
 
 ```ts
 const tagged = tx.input
@@ -76,7 +88,7 @@ const tagged = tx.input
   .includes(identifier.toLowerCase());
 ```
 
-Good enough for quick dashboards, but batches of multiple userOps in one `handleOps` call appear as one match. Prefer the event-based approach above.
+Good enough for quick dashboards, but batches of multiple userOps in one `handleOps` call collapse into one match. For per-userOp attribution, decode the ops array (ABI-decode the tx input) and check each op's `callData` individually, or prefer the event-based approach above.
 
 ## Full example
 
@@ -147,6 +159,6 @@ Truncated hash of the tool's version (for example, "1.0.0", "1.0.1").
 
 ## Submission Form
 
-The Safe Team aim to understand better and recognise key contributors who are driving the adoption of smart accounts within the Ecosystem. By submitting your on-chain identifiers through the provided form, you will help Safe accurately attribute activity.
+The Safe team aims to better understand and recognise key contributors who are driving the adoption of smart accounts within the ecosystem. By submitting your on-chain identifiers through the provided form, you will help Safe accurately attribute activity.
 
 You can fill out the form by clicking [this link](https://forms.gle/NYkorYebc6Fz1fMW6).

--- a/docs/wallet/guides/onchain-identifiers.mdx
+++ b/docs/wallet/guides/onchain-identifiers.mdx
@@ -6,79 +6,140 @@ keywords: [Identifier, on-chain]
 
 # On-Chain Tracking - Adding an Identifier to Your Safe Accounts
 
-This guide explains how to add an on-chain identifier to your Safe Accounts, enabling you to track and distinguish your Safe transactions from other wallets and monitor user adoption.
+Attribute active users and UserOperations to your project by tagging each userOp's `callData` with a 32-byte marker. Your indexer filters on the marker, no extra infrastructure, no off-chain correlation.
 
-## Generate an On-Chain Identifier  
+## Generate an On-Chain Identifier
+
+Pass `onChainIdentifierParams` when you initialize the Safe account. The SDK appends the marker to every userOp's `callData`.
 
 ```ts
-import { SafeAccountV0_3_0 } from "abstractionkit"
+import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
 
-const smartAccount = SafeAccountV0_3_0.initializeNewAccount(
-    [ownerPublicAddress],
-    //highlight-start
-    { onChainIdentifierParams: { project: "PROJECT_NAME" } }
-    //highlight-end
-)
+const smartAccount = SafeAccount.initializeNewAccount([ownerPublicAddress], {
+  //highlight-start
+  onChainIdentifierParams: {
+    project: "YourProject",        // required — the thing you key analytics off
+    platform: "Web",               // optional — 'Web' | 'Mobile' | 'Safe App' | 'Widget'
+    tool: "abstractionkit",        // optional — which SDK
+    toolVersion: "0.3.2",          // optional — SDK version
+  },
+  //highlight-end
+});
 ```
 
-This example initializes a new Safe account with an `onChainIdentifierParams` object containing a project property set to "PROJECT_NAME".
-This adds a unique identifier to all transactions from this Safe account, enabling easy tracking and recognition among other Safe wallet transactions.
+Only `project` is required. `platform`, `tool`, and `toolVersion` refine attribution (Web vs Mobile, which SDK, which version). Use the same values everywhere, analytics key off this exact string.
+
+### Already-deployed accounts
+
+For accounts that already exist on-chain, pass the same params to the constructor. New userOps will carry the marker from that point on; historical userOps are not retroactively tagged.
+
+```ts
+const smartAccount = new SafeAccount(accountAddress, {
+  onChainIdentifierParams: { project: "YourProject" },
+});
+```
 
 ## Getting the On-Chain Identifier
 
 ```ts
-const onchainIdentifier = smartAccount.onChainIdentifier
+const onchainIdentifier = smartAccount.onChainIdentifier;
+// "0x5afe00..."
 ```
 
-The `onChainIdentifier` property contains the generated identifier and additional information about the tooling used.
+View the identifier generation in the [generateOnChainIdentifier](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccount.ts) source code.
 
-View the identifier generation in the [generateOnChainIdentifier](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccount.ts#L2819) source code. 
+## Indexer patterns
+
+### Exact match: `UserOperationEvent`
+
+The EntryPoint emits a `UserOperationEvent` log for every included userOp. Decode it, pull the userOp's `callData`, and check the suffix. This is the right approach: it's per-userOp and the marker sits exactly at the tail.
+
+```ts
+const endsWithId = userOp.callData
+  .toLowerCase()
+  .endsWith(identifier.toLowerCase());
+```
+
+Aggregate:
+
+- Unique `sender` values → active users
+- Total matching events → userOp volume
+- Group by the identifier's trailing hashes → split by platform / tool / version
+
+### Fuzzy match: `handleOps` tx input
+
+The bundler wraps the userOp in `EntryPoint.handleOps(ops[], beneficiary)`. The marker ends up inside the tx `input`, not at the tail, because a trailing beneficiary address sits after it. Use substring (not suffix) match:
+
+```ts
+const tagged = tx.input
+  .toLowerCase()
+  .includes(identifier.toLowerCase());
+```
+
+Good enough for quick dashboards, but batches of multiple userOps in one `handleOps` call appear as one match. Prefer the event-based approach above.
+
+## Full example
+
+A complete working script (Safe v0.3.0 on Arbitrum Sepolia, with sponsored gas and a mint transaction) is available on GitHub: [onchain-identifier.ts](https://github.com/candidelabs/abstractionkit-examples/blob/main/onchain-identifier/onchain-identifier.ts).
+
+## Marker layout
 
 <details>
 <summary>What's the format of the identifier?</summary>
 
-The identifiers used to track Safe deployments are 50 bytes in length and follow the format below:
+The identifier is 32 bytes and follows the format below:
 
 `5afe` `00` `6363643438383836663461336661366162653539` `646561` `393238` `653366`
 
-Check the last 50 bytes of the data field in this [example transaction](https://sepolia.etherscan.io/tx/0xe0192eedd1fc2d06be0561d57380d610dd6d162af0f3cfbd6c08f9062d738761)
-to see how the identifier appears after the transaction is executed.
+Check the last 32 bytes of the `callData` field in a `UserOperationEvent` log, or inside the `handleOps` tx input, to see how the identifier appears after the transaction is executed.
+
+```text
+5afe │ 00 │ project(20) │ platform(3) │ tool(3) │ toolVersion(3)
+└─prefix  │
+   version
+```
+
+Each variable-content field is `keccak256(value)` truncated to its byte width.
 
 #### Prefix hash
 
 - Type: 2 bytes
-- Example: 5afe
+- Example: `5afe`
 
 Static prefix to identify the Safe on-chain identifier.
 
 #### Version hash
 
 - Type: 1 byte
-- Example: 00
+- Example: `00`
 
 Version number of the Safe on-chain identifier format.
+
 #### Project hash
 
 - Type: 20 bytes
-- Example: 6363643438383836663461336661366162653539
+- Example: `6363643438383836663461336661366162653539`
 
 Truncated hash of the project's name (for example, "Gnosis", "CoW Swap").
+
 #### Platform hash
 
 - Type: 3 bytes
-- Example: 646561
+- Example: `646561`
 
 Truncated hash of the platform's name (for example, "Web", "Mobile", "Safe App", "Widget").
+
 #### Tool hash
 
 - Type: 3 bytes
-- Example: 393238
+- Example: `393238`
 
 Truncated hash of the tool's name (for example, "protocol-kit", "relay-kit", or any custom tool built by projects).
+
 #### Tool version hash
 
 - Type: 3 bytes
-- Example: 653366
+- Example: `653366`
 
 Truncated hash of the tool's version (for example, "1.0.0", "1.0.1").
 
@@ -86,8 +147,6 @@ Truncated hash of the tool's version (for example, "1.0.0", "1.0.1").
 
 ## Submission Form
 
-The Safe Team aim to understand better and recognise key contributors who are driving the adoption of smart accounts within the Ecosystem. 
-By submitting your on-chain identifiers through the provided form, you will help Safe accurately attribute activity.
+The Safe Team aim to understand better and recognise key contributors who are driving the adoption of smart accounts within the Ecosystem. By submitting your on-chain identifiers through the provided form, you will help Safe accurately attribute activity.
 
-You can fill out the form by clicking [this link](https://forms.gle/NYkorYebc6Fz1fMW6)
-
+You can fill out the form by clicking [this link](https://forms.gle/NYkorYebc6Fz1fMW6).

--- a/src/data/accountParamAndReturnData.ts
+++ b/src/data/accountParamAndReturnData.ts
@@ -1835,18 +1835,13 @@ export const getMultiChainEip712DataReturn = [
 export const formatSignaturesToUseroperationsSignaturesParam = [
   {
     key: "userOperationsToSign",
-    type: "UserOperationToSign[]",
-    description: "Array of UserOperations with their target chain IDs",
+    type: "UserOperationToSignWithOverrides[]",
+    description: "Array of UserOperations with their target chain IDs and optional per-operation overrides (e.g. WebAuthn verifier addresses)",
   },
   {
     key: "signerSignaturePairs",
     type: "SignerSignaturePair[]",
     description: "Array of signer address and signature pairs from EIP-712 signing",
-  },
-  {
-    key: "overrides?",
-    type: "WebAuthnSignatureOverrides",
-    description: "Optional overrides for WebAuthn verifier addresses",
   },
 ];
 

--- a/src/data/caliburAccountParams.ts
+++ b/src/data/caliburAccountParams.ts
@@ -350,9 +350,9 @@ export const signUserOperationWithSignerParam = [
   },
   {
     key: "signer",
-    type: "SignerFunction",
+    type: "ExternalSigner",
     description:
-      "Async signing function: (hash: string) => Promise<string>. Use this to integrate viem, ethers Signers, hardware wallets, or MPC signers.",
+      "A capability-oriented signer: { address, signHash?, signTypedData? }. Use one of the built-in adapters (fromPrivateKey, fromViem, fromEthersWallet, fromViemWalletClient) or implement the interface yourself to integrate hardware wallets, HSMs, MPC, or WebAuthn. Calibur requires a signer that implements signHash.",
   },
   {
     key: "chainId",


### PR DESCRIPTION
## Summary

Brings the docs in line with AbstractionKit v0.3.1 and v0.3.2.

- **New ExternalSigner API (v0.3.2):** central reference in the authentication guide with adapter table (`fromViem`, `fromEthersWallet`, `fromViemWalletClient`, custom) and capability-negotiation rules. Short per-account stubs cross-link back: Safe V0.2.0 / V0.3.0, Simple7702 v0.8 / v0.9, Calibur, Safe Unified Account.
- **Breaking changes documented:**
  - Calibur `signUserOperationWithSigner` — old callback API removed, replaced with `ExternalSigner`.
  - `SafeMultiChainSigAccountV1.formatSignaturesToUseroperationsSignatures` — third `overrides` argument removed, overrides are now per-op.
- **New `Erc7677Paymaster` section** on the paymaster reference page (v0.3.1).
- **Onchain identifiers guide rewrite:** expanded params (platform/tool/toolVersion), already-deployed accounts, indexer patterns (`UserOperationEvent` suffix match, `handleOps` fuzzy match), link to the new [example script](https://github.com/candidelabs/abstractionkit-examples/tree/main/onchain-identifier), and fixed marker length from 50 → 32 bytes.

Example scripts are linked directly to `candidelabs/abstractionkit-examples` rather than embedded, so they stay maintained in one place.

## Test plan

- [x] `yarn build` passes
- [ ] Manually verify the new authentication → External Signers anchor renders and all per-account cross-links resolve
- [ ] Spot-check the `Erc7677Paymaster` section and onchain-identifier indexer snippets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External Signers docs and examples added across multiple account types (adapter-based signing, multi-signer flows)
  * ERC-7677 paymaster client introduced with ERC-20 sponsorship support and provider auto-detection
  * On-chain identifier tagging added for ERC-4337 operations

* **Documentation**
  * Authentication and getting-started guides refocused on External Signers (usage guidance and examples)
  * Signature formatting docs updated to allow per-operation overrides and clarify signer capabilities (hash-signing requirement)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->