### PR TITLE
docs: pin abstractionkit source links to v0.3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 
 
 .worktrees
+.cache-abstractionkit-*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 .docusaurus
 build
 
+
+.worktrees

--- a/docs/wallet/abstractionkit/12-calibur-account.mdx
+++ b/docs/wallet/abstractionkit/12-calibur-account.mdx
@@ -212,7 +212,7 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L233)
+[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### signUserOperation
 
@@ -251,7 +251,7 @@ userOperation.signature = smartAccount.signUserOperation(
 </Tabs>
 
 #### Source code
-[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L563)
+[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### signUserOperationWithSigner
 
@@ -294,7 +294,7 @@ userOperation.signature = await smartAccount.signUserOperationWithSigner(
 </Tabs>
 
 #### Source code
-[signUserOperationWithSigner](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L604)
+[signUserOperationWithSigner](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### formatWebAuthnSignature
 
@@ -340,7 +340,7 @@ userOperation.signature = smartAccount.formatWebAuthnSignature(
 </Tabs>
 
 #### Source code
-[formatWebAuthnSignature](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L630)
+[formatWebAuthnSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### sendUserOperation
 
@@ -381,7 +381,7 @@ console.log("Transaction receipt:", receipt);
 </Tabs>
 
 #### Source code
-[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L666)
+[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ## Key Management Methods
 
@@ -417,7 +417,7 @@ console.log(key);
 </Tabs>
 
 #### Source code
-[createSecp256k1Key](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L690)
+[createSecp256k1Key](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### createWebAuthnP256Key
 
@@ -453,7 +453,7 @@ console.log("Key hash:", keyHash);
 </Tabs>
 
 #### Source code
-[createWebAuthnP256Key](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L704)
+[createWebAuthnP256Key](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### createP256Key
 
@@ -488,7 +488,7 @@ console.log("Key hash:", keyHash);
 </Tabs>
 
 #### Source code
-[createP256Key](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L718)
+[createP256Key](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### getKeyHash
 
@@ -522,7 +522,7 @@ console.log("Key hash:", keyHash);
 </Tabs>
 
 #### Source code
-[getKeyHash](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L733)
+[getKeyHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### createRegisterKeyMetaTransactions
 
@@ -568,7 +568,7 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createRegisterKeyMetaTransactions](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L785)
+[createRegisterKeyMetaTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### createRevokeKeyMetaTransaction
 
@@ -604,7 +604,7 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createRevokeKeyMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L829)
+[createRevokeKeyMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### createUpdateKeySettingsMetaTransaction
 
@@ -648,7 +648,7 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createUpdateKeySettingsMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L852)
+[createUpdateKeySettingsMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### packKeySettings
 
@@ -684,7 +684,7 @@ console.log("Packed settings:", packed);
 </Tabs>
 
 #### Source code
-[packKeySettings](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L750)
+[packKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### unpackKeySettings
 
@@ -719,7 +719,7 @@ console.log("Hook:", settings.hook);
 </Tabs>
 
 #### Source code
-[unpackKeySettings](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L763)
+[unpackKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ## Read Methods
 
@@ -753,7 +753,7 @@ console.log("Key registered:", isRegistered);
 </Tabs>
 
 #### Source code
-[isKeyRegistered](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L935)
+[isKeyRegistered](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### getKeySettings
 
@@ -789,7 +789,7 @@ console.log("Hook:", settings.hook);
 </Tabs>
 
 #### Source code
-[getKeySettings](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L975)
+[getKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### getKey
 
@@ -824,7 +824,7 @@ console.log("Public key:", key.publicKey);
 </Tabs>
 
 #### Source code
-[getKey](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L1015)
+[getKey](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### listKeys
 
@@ -860,7 +860,7 @@ for (const key of keys) {
 </Tabs>
 
 #### Source code
-[listKeys](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L1059)
+[listKeys](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### isDelegated
 
@@ -894,7 +894,7 @@ if (isDelegated) {
 </Tabs>
 
 #### Source code
-[isDelegated](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L903)
+[isDelegated](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### getNonce
 
@@ -930,7 +930,7 @@ const parallelNonce = await smartAccount.getNonce(
 </Tabs>
 
 #### Source code
-[getNonce](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L916)
+[getNonce](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ## Utility Methods
 
@@ -968,7 +968,7 @@ const callDataNoRevert = Calibur7702Account.createAccountCallData(transactions, 
 </Tabs>
 
 #### Source code
-[createAccountCallData](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L203)
+[createAccountCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### wrapSignature
 
@@ -1012,7 +1012,7 @@ const wrappedWithHook = Calibur7702Account.wrapSignature(
 </Tabs>
 
 #### Source code
-[wrapSignature](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L137)
+[wrapSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### createDummyWebAuthnSignature
 
@@ -1050,7 +1050,7 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createDummyWebAuthnSignature](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L103)
+[createDummyWebAuthnSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### getUserOperationHash
 
@@ -1082,7 +1082,7 @@ console.log("UserOperation hash:", userOpHash);
 </Tabs>
 
 #### Source code
-[getUserOperationHash](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L182)
+[getUserOperationHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### prependTokenPaymasterApproveToCallData
 
@@ -1115,7 +1115,7 @@ userOperation.callData = callDataWithApproval;
 </Tabs>
 
 #### Source code
-[prependTokenPaymasterApproveToCallData](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L1133)
+[prependTokenPaymasterApproveToCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
 
 ### createInvalidateNonceMetaTransaction
 
@@ -1150,4 +1150,4 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createInvalidateNonceMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Calibur/Calibur7702Account.ts#L880)
+[createInvalidateNonceMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)

--- a/docs/wallet/abstractionkit/12-calibur-account.mdx
+++ b/docs/wallet/abstractionkit/12-calibur-account.mdx
@@ -212,7 +212,7 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L242)
 
 ### signUserOperation
 
@@ -251,7 +251,7 @@ userOperation.signature = smartAccount.signUserOperation(
 </Tabs>
 
 #### Source code
-[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L594)
 
 ### signUserOperationWithSigner
 
@@ -294,7 +294,7 @@ userOperation.signature = await smartAccount.signUserOperationWithSigner(
 </Tabs>
 
 #### Source code
-[signUserOperationWithSigner](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[signUserOperationWithSigner](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L635)
 
 ### formatWebAuthnSignature
 
@@ -340,7 +340,7 @@ userOperation.signature = smartAccount.formatWebAuthnSignature(
 </Tabs>
 
 #### Source code
-[formatWebAuthnSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[formatWebAuthnSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L670)
 
 ### sendUserOperation
 
@@ -381,7 +381,7 @@ console.log("Transaction receipt:", receipt);
 </Tabs>
 
 #### Source code
-[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L706)
 
 ## Key Management Methods
 
@@ -417,7 +417,7 @@ console.log(key);
 </Tabs>
 
 #### Source code
-[createSecp256k1Key](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[createSecp256k1Key](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L730)
 
 ### createWebAuthnP256Key
 
@@ -453,7 +453,7 @@ console.log("Key hash:", keyHash);
 </Tabs>
 
 #### Source code
-[createWebAuthnP256Key](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[createWebAuthnP256Key](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L744)
 
 ### createP256Key
 
@@ -488,7 +488,7 @@ console.log("Key hash:", keyHash);
 </Tabs>
 
 #### Source code
-[createP256Key](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[createP256Key](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L758)
 
 ### getKeyHash
 
@@ -522,7 +522,7 @@ console.log("Key hash:", keyHash);
 </Tabs>
 
 #### Source code
-[getKeyHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[getKeyHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L773)
 
 ### createRegisterKeyMetaTransactions
 
@@ -568,7 +568,7 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createRegisterKeyMetaTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[createRegisterKeyMetaTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L825)
 
 ### createRevokeKeyMetaTransaction
 
@@ -604,7 +604,7 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createRevokeKeyMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[createRevokeKeyMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L869)
 
 ### createUpdateKeySettingsMetaTransaction
 
@@ -648,7 +648,7 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createUpdateKeySettingsMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[createUpdateKeySettingsMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L1065)
 
 ### packKeySettings
 
@@ -684,7 +684,7 @@ console.log("Packed settings:", packed);
 </Tabs>
 
 #### Source code
-[packKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[packKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L790)
 
 ### unpackKeySettings
 
@@ -719,7 +719,7 @@ console.log("Hook:", settings.hook);
 </Tabs>
 
 #### Source code
-[unpackKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[unpackKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L803)
 
 ## Read Methods
 
@@ -753,7 +753,7 @@ console.log("Key registered:", isRegistered);
 </Tabs>
 
 #### Source code
-[isKeyRegistered](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[isKeyRegistered](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L1148)
 
 ### getKeySettings
 
@@ -789,7 +789,7 @@ console.log("Hook:", settings.hook);
 </Tabs>
 
 #### Source code
-[getKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[getKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L1188)
 
 ### getKey
 
@@ -824,7 +824,7 @@ console.log("Public key:", key.publicKey);
 </Tabs>
 
 #### Source code
-[getKey](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[getKey](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L1228)
 
 ### listKeys
 
@@ -860,7 +860,7 @@ for (const key of keys) {
 </Tabs>
 
 #### Source code
-[listKeys](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[listKeys](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L1059)
 
 ### isDelegated
 
@@ -894,7 +894,7 @@ if (isDelegated) {
 </Tabs>
 
 #### Source code
-[isDelegated](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[isDelegated](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L903)
 
 ### getNonce
 
@@ -930,7 +930,7 @@ const parallelNonce = await smartAccount.getNonce(
 </Tabs>
 
 #### Source code
-[getNonce](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[getNonce](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L1129)
 
 ## Utility Methods
 
@@ -968,7 +968,7 @@ const callDataNoRevert = Calibur7702Account.createAccountCallData(transactions, 
 </Tabs>
 
 #### Source code
-[createAccountCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[createAccountCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L212)
 
 ### wrapSignature
 
@@ -1012,7 +1012,7 @@ const wrappedWithHook = Calibur7702Account.wrapSignature(
 </Tabs>
 
 #### Source code
-[wrapSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[wrapSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L146)
 
 ### createDummyWebAuthnSignature
 
@@ -1050,7 +1050,7 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createDummyWebAuthnSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[createDummyWebAuthnSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L109)
 
 ### getUserOperationHash
 
@@ -1082,7 +1082,7 @@ console.log("UserOperation hash:", userOpHash);
 </Tabs>
 
 #### Source code
-[getUserOperationHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[getUserOperationHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L191)
 
 ### prependTokenPaymasterApproveToCallData
 
@@ -1115,7 +1115,7 @@ userOperation.callData = callDataWithApproval;
 </Tabs>
 
 #### Source code
-[prependTokenPaymasterApproveToCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[prependTokenPaymasterApproveToCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L1378)
 
 ### createInvalidateNonceMetaTransaction
 
@@ -1150,4 +1150,4 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createInvalidateNonceMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts)
+[createInvalidateNonceMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L1093)

--- a/docs/wallet/abstractionkit/13-safe-unified-account.mdx
+++ b/docs/wallet/abstractionkit/13-safe-unified-account.mdx
@@ -87,7 +87,7 @@ console.log("Account address (sender): " + smartAccount.accountAddress);
 
 #### Source code
 
-[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeMultiChainSigAccount.ts)
+[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeMultiChainSigAccount.ts)
 
 ### createUserOperation
 
@@ -129,7 +129,7 @@ const userOperation = await smartAccount.createUserOperation(
 
 #### Source code
 
-[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeMultiChainSigAccount.ts)
+[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeMultiChainSigAccount.ts)
 
 ### signUserOperations
 
@@ -180,7 +180,7 @@ userOp2.signature = signatures[1];
 
 #### Source code
 
-[signUserOperations](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeMultiChainSigAccount.ts)
+[signUserOperations](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeMultiChainSigAccount.ts)
 
 ### getMultiChainSingleSignatureUserOperationsEip712Hash
 
@@ -215,7 +215,7 @@ const hash = SafeAccount.getMultiChainSingleSignatureUserOperationsEip712Hash([
 
 #### Source code
 
-[getMultiChainSingleSignatureUserOperationsEip712Hash](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeMultiChainSigAccount.ts)
+[getMultiChainSingleSignatureUserOperationsEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeMultiChainSigAccount.ts)
 
 ### getMultiChainSingleSignatureUserOperationsEip712Data
 
@@ -254,7 +254,7 @@ const signature = await wallet.signTypedData(domain, types, messageValue);
 
 #### Source code
 
-[getMultiChainSingleSignatureUserOperationsEip712Data](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeMultiChainSigAccount.ts)
+[getMultiChainSingleSignatureUserOperationsEip712Data](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeMultiChainSigAccount.ts)
 
 ### formatSignaturesToUseroperationsSignatures
 
@@ -301,7 +301,7 @@ userOp2.signature = signatures[1];
 
 #### Source code
 
-[formatSignaturesToUseroperationsSignatures](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeMultiChainSigAccount.ts)
+[formatSignaturesToUseroperationsSignatures](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeMultiChainSigAccount.ts)
 
 ### sendUserOperation
 

--- a/docs/wallet/abstractionkit/3.paymaster.mdx
+++ b/docs/wallet/abstractionkit/3.paymaster.mdx
@@ -119,7 +119,7 @@ const [sponsoredUserOperation, sponsorMetadata] =
 </Tabs>
 
 #### Source code
-[createSponsorPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/main/src/paymaster/CandidePaymaster.ts#L548)
+[createSponsorPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts)
 
 ### fetchSupportedERC20TokensAndPaymasterMetadata
 
@@ -272,7 +272,7 @@ userOperation = await paymaster.createTokenPaymasterUserOperation(
 </details>
 
 #### Source code
-[createTokenPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/main/src/paymaster/CandidePaymaster.ts#L590)
+[createTokenPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts)
 
 ### calculateUserOperationErc20TokenMaxGasCost
 
@@ -319,7 +319,7 @@ const cost = await paymaster.calculateUserOperationErc20TokenMaxGasCost(
 </details>
 
 #### Source code
-[calculateUserOperationErc20TokenMaxGasCost](https://github.com/candidelabs/abstractionkit/blob/main/src/paymaster/CandidePaymaster.ts#L684)
+[calculateUserOperationErc20TokenMaxGasCost](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts)
 
 ## Advanced Methods
 
@@ -380,7 +380,7 @@ const paymasterResult = await paymaster.getPaymasterMetaData(SafeAccount.DEFAULT
 
 #### source code
 
-[getPaymasterMetaData](https://github.com/candidelabs/abstractionkit/blob/main/src/paymaster/CandidePaymaster.ts#L319)
+[getPaymasterMetaData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts)
 
 ### getSupportedEntrypoints
 
@@ -419,7 +419,7 @@ const paymasterResult = await paymaster.getSupportedEntrypoints();
 </details>
 
 #### source code
-[getSupportedEntrypoints](https://github.com/candidelabs/abstractionkit/blob/main/src/paymaster/CandidePaymaster.ts#L290)
+[getSupportedEntrypoints](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts)
 
 ### isSupportedERC20Token
 
@@ -460,7 +460,7 @@ true
 </details>
 
 #### Source
-[isSupportedERC20Token](https://github.com/candidelabs/abstractionkit/blob/main/src/paymaster/CandidePaymaster.ts#L338)
+[isSupportedERC20Token](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts)
 
 ### getSupportedERC20TokenData
 
@@ -509,7 +509,7 @@ const erc20TokenData = await paymaster.getSupportedERC20TokenData(erc20TokenAddr
 </details>
 
 #### Source code
-[getSupportedERC20TokenData](https://github.com/candidelabs/abstractionkit/blob/main/src/paymaster/CandidePaymaster.ts#L357)
+[getSupportedERC20TokenData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts)
 
 ### fetchTokenPaymasterExchangeRate
 
@@ -552,7 +552,7 @@ const exchangeRate = await paymaster.fetchTokenPaymasterExchangeRate(erc20TokenA
 </details>
 
 #### Source code
-[fetchTokenPaymasterExchangeRate](https://github.com/candidelabs/abstractionkit/blob/main/src/paymaster/CandidePaymaster.ts#L719)
+[fetchTokenPaymasterExchangeRate](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts)
 
 ### createPaymasterUserOperation
 
@@ -561,4 +561,4 @@ const exchangeRate = await paymaster.fetchTokenPaymasterExchangeRate(erc20TokenA
 :::
 
 #### Source code
-[createPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/main/src/paymaster/CandidePaymaster.ts#L508)
+[createPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts)

--- a/docs/wallet/abstractionkit/3.paymaster.mdx
+++ b/docs/wallet/abstractionkit/3.paymaster.mdx
@@ -119,7 +119,7 @@ const [sponsoredUserOperation, sponsorMetadata] =
 </Tabs>
 
 #### Source code
-[createSponsorPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts)
+[createSponsorPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts#L546)
 
 ### fetchSupportedERC20TokensAndPaymasterMetadata
 
@@ -272,7 +272,7 @@ userOperation = await paymaster.createTokenPaymasterUserOperation(
 </details>
 
 #### Source code
-[createTokenPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts)
+[createTokenPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts#L590)
 
 ### calculateUserOperationErc20TokenMaxGasCost
 
@@ -319,7 +319,7 @@ const cost = await paymaster.calculateUserOperationErc20TokenMaxGasCost(
 </details>
 
 #### Source code
-[calculateUserOperationErc20TokenMaxGasCost](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts)
+[calculateUserOperationErc20TokenMaxGasCost](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts#L690)
 
 ## Advanced Methods
 
@@ -380,7 +380,7 @@ const paymasterResult = await paymaster.getPaymasterMetaData(SafeAccount.DEFAULT
 
 #### source code
 
-[getPaymasterMetaData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts)
+[getPaymasterMetaData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts#L316)
 
 ### getSupportedEntrypoints
 
@@ -419,7 +419,7 @@ const paymasterResult = await paymaster.getSupportedEntrypoints();
 </details>
 
 #### source code
-[getSupportedEntrypoints](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts)
+[getSupportedEntrypoints](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts#L287)
 
 ### isSupportedERC20Token
 
@@ -460,7 +460,7 @@ true
 </details>
 
 #### Source
-[isSupportedERC20Token](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts)
+[isSupportedERC20Token](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts#L335)
 
 ### getSupportedERC20TokenData
 
@@ -509,7 +509,7 @@ const erc20TokenData = await paymaster.getSupportedERC20TokenData(erc20TokenAddr
 </details>
 
 #### Source code
-[getSupportedERC20TokenData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts)
+[getSupportedERC20TokenData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts#L354)
 
 ### fetchTokenPaymasterExchangeRate
 
@@ -552,7 +552,7 @@ const exchangeRate = await paymaster.fetchTokenPaymasterExchangeRate(erc20TokenA
 </details>
 
 #### Source code
-[fetchTokenPaymasterExchangeRate](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts)
+[fetchTokenPaymasterExchangeRate](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts#L726)
 
 ### createPaymasterUserOperation
 
@@ -561,4 +561,4 @@ const exchangeRate = await paymaster.fetchTokenPaymasterExchangeRate(erc20TokenA
 :::
 
 #### Source code
-[createPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts)
+[createPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/paymaster/CandidePaymaster.ts#L505)

--- a/docs/wallet/abstractionkit/4.utilities.mdx
+++ b/docs/wallet/abstractionkit/4.utilities.mdx
@@ -94,7 +94,7 @@ const userOpHash = createUserOperationHash(
 </Tabs>
 
 #### Source code
-[createUserOperationHash](https://github.com/candidelabs/abstractionkit/blob/main/src/utils.ts)
+[createUserOperationHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utils.ts)
 
 ### createPackedUserOperationV6
 
@@ -119,7 +119,7 @@ const packed = createPackedUserOperationV6(userOperationV6);
 </Tabs>
 
 #### Source code
-[createPackedUserOperationV6](https://github.com/candidelabs/abstractionkit/blob/main/src/utils.ts)
+[createPackedUserOperationV6](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utils.ts)
 
 ### createPackedUserOperationV7
 
@@ -144,7 +144,7 @@ const packed = createPackedUserOperationV7(userOperationV7);
 </Tabs>
 
 #### Source code
-[createPackedUserOperationV7](https://github.com/candidelabs/abstractionkit/blob/main/src/utils.ts)
+[createPackedUserOperationV7](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utils.ts)
 
 ### fetchAccountNonce
 
@@ -173,7 +173,7 @@ const nonce = await fetchAccountNonce(
 </Tabs>
 
 #### Source code
-[fetchAccountNonce](https://github.com/candidelabs/abstractionkit/blob/main/src/utils.ts)
+[fetchAccountNonce](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utils.ts)
 
 ### calculateUserOperationMaxGasCost
 
@@ -198,7 +198,7 @@ const maxCost = calculateUserOperationMaxGasCost(userOperation);
 </Tabs>
 
 #### Source code
-[calculateUserOperationMaxGasCost](https://github.com/candidelabs/abstractionkit/blob/main/src/utils.ts)
+[calculateUserOperationMaxGasCost](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utils.ts)
 
 ### getBalanceOf
 
@@ -227,7 +227,7 @@ const balance = await getBalanceOf(
 </Tabs>
 
 #### Source code
-[getBalanceOf](https://github.com/candidelabs/abstractionkit/blob/main/src/utils.ts)
+[getBalanceOf](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utils.ts)
 
 ### getDepositInfo
 
@@ -258,7 +258,7 @@ const info = await getDepositInfo(
 </Tabs>
 
 #### Source code
-[getDepositInfo](https://github.com/candidelabs/abstractionkit/blob/main/src/utils.ts)
+[getDepositInfo](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utils.ts)
 
 ## Simulation utils
 
@@ -293,7 +293,7 @@ const { simulation, simulationShareLink } =
 </Tabs>
 
 #### Source code
-[simulateUserOperationWithTenderlyAndCreateShareLink](https://github.com/candidelabs/abstractionkit/blob/main/src/utilsTenderly.ts)
+[simulateUserOperationWithTenderlyAndCreateShareLink](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utilsTenderly.ts)
 
 ### simulateUserOperationCallDataWithTenderlyAndCreateShareLink
 
@@ -326,7 +326,7 @@ const { simulation, callDataSimulationShareLink } =
 </Tabs>
 
 #### Source code
-[simulateUserOperationCallDataWithTenderlyAndCreateShareLink](https://github.com/candidelabs/abstractionkit/blob/main/src/utilsTenderly.ts)
+[simulateUserOperationCallDataWithTenderlyAndCreateShareLink](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utilsTenderly.ts)
 
 ### simulateSenderCallDataWithTenderlyAndCreateShareLink
 
@@ -360,7 +360,7 @@ const { simulation, callDataSimulationShareLink } =
 </Tabs>
 
 #### Source code
-[simulateSenderCallDataWithTenderlyAndCreateShareLink](https://github.com/candidelabs/abstractionkit/blob/main/src/utilsTenderly.ts)
+[simulateSenderCallDataWithTenderlyAndCreateShareLink](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utilsTenderly.ts)
 
 ## Multicall utils
 
@@ -402,7 +402,7 @@ const callData = encodeMultiSendCallData([
 </Tabs>
 
 #### Source code
-[encodeMultiSendCallData](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/multisend.ts)
+[encodeMultiSendCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/multisend.ts)
 
 ### decodeMultiSendCallData
 
@@ -427,7 +427,7 @@ const decoded = decodeMultiSendCallData(encodedCallData);
 </Tabs>
 
 #### Source code
-[decodeMultiSendCallData](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/multisend.ts)
+[decodeMultiSendCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/multisend.ts)
 
 ## Generic Ethereum utils
 
@@ -457,7 +457,7 @@ const [maxFeePerGas, maxPriorityFeePerGas] = await fetchGasPrice(
 </Tabs>
 
 #### Source code
-[fetchGasPrice](https://github.com/candidelabs/abstractionkit/blob/main/src/utils.ts)
+[fetchGasPrice](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utils.ts)
 
 ### createCallData
 
@@ -486,7 +486,7 @@ const callData = createCallData(
 </Tabs>
 
 #### Source code
-[createCallData](https://github.com/candidelabs/abstractionkit/blob/main/src/utils.ts)
+[createCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utils.ts)
 
 ### getFunctionSelector
 
@@ -512,7 +512,7 @@ const selector = getFunctionSelector("transfer(address,uint256)");
 </Tabs>
 
 #### Source code
-[getFunctionSelector](https://github.com/candidelabs/abstractionkit/blob/main/src/utils.ts)
+[getFunctionSelector](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utils.ts)
 
 ### sendJsonRpcRequest
 
@@ -541,7 +541,7 @@ const result = await sendJsonRpcRequest(
 </Tabs>
 
 #### Source code
-[sendJsonRpcRequest](https://github.com/candidelabs/abstractionkit/blob/main/src/utils.ts)
+[sendJsonRpcRequest](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utils.ts)
 
 ### sendEthCallRequest
 
@@ -573,7 +573,7 @@ const result = await sendEthCallRequest(
 </Tabs>
 
 #### Source code
-[sendEthCallRequest](https://github.com/candidelabs/abstractionkit/blob/main/src/utils.ts)
+[sendEthCallRequest](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utils.ts)
 
 ### sendEthGetCodeRequest
 
@@ -602,7 +602,7 @@ const code = await sendEthGetCodeRequest(
 </Tabs>
 
 #### Source code
-[sendEthGetCodeRequest](https://github.com/candidelabs/abstractionkit/blob/main/src/utils.ts)
+[sendEthGetCodeRequest](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utils.ts)
 
 ### getDelegatedAddress
 
@@ -636,7 +636,7 @@ if (delegatee) {
 </Tabs>
 
 #### Source code
-[getDelegatedAddress](https://github.com/candidelabs/abstractionkit/blob/main/src/utils.ts)
+[getDelegatedAddress](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utils.ts)
 
 ## EIP-7702 Utilities
 
@@ -682,7 +682,7 @@ const authorization = await createAndSignEip7702DelegationAuthorization(
 </Tabs>
 
 #### Source code
-[createAndSignEip7702DelegationAuthorization](https://github.com/candidelabs/abstractionkit/blob/main/src/utils7702.ts)
+[createAndSignEip7702DelegationAuthorization](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utils7702.ts)
 
 ### createRevokeDelegationAuthorization
 
@@ -713,7 +713,7 @@ const revokeAuth = createRevokeDelegationAuthorization(
 </Tabs>
 
 #### Source code
-[createRevokeDelegationAuthorization](https://github.com/candidelabs/abstractionkit/blob/main/src/utils7702.ts)
+[createRevokeDelegationAuthorization](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utils7702.ts)
 
 ### createEip7702DelegationAuthorizationHash
 
@@ -742,7 +742,7 @@ const hash = createEip7702DelegationAuthorizationHash(
 </Tabs>
 
 #### Source code
-[createEip7702DelegationAuthorizationHash](https://github.com/candidelabs/abstractionkit/blob/main/src/utils7702.ts)
+[createEip7702DelegationAuthorizationHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utils7702.ts)
 
 ### createAndSignEip7702RawTransaction
 
@@ -779,7 +779,7 @@ const rawTx = createAndSignEip7702RawTransaction(
 </Tabs>
 
 #### Source code
-[createAndSignEip7702RawTransaction](https://github.com/candidelabs/abstractionkit/blob/main/src/utils7702.ts)
+[createAndSignEip7702RawTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utils7702.ts)
 
 ### createEip7702TransactionHash
 
@@ -815,4 +815,4 @@ const txHash = createEip7702TransactionHash(
 </Tabs>
 
 #### Source code
-[createEip7702TransactionHash](https://github.com/candidelabs/abstractionkit/blob/main/src/utils7702.ts)
+[createEip7702TransactionHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/utils7702.ts)

--- a/docs/wallet/abstractionkit/7-safe-account-v2.mdx
+++ b/docs/wallet/abstractionkit/7-safe-account-v2.mdx
@@ -114,7 +114,7 @@ const smartAccount = new SafeAccount(accountAddress);
 
 #### Source code
 
-[constructor](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_2_0.ts#L43)
+[constructor](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
 
 ## Methods
 
@@ -166,7 +166,7 @@ Account address(sender) : 0x1a02592A3484c2077d2E5D24482497F85e1980C6
 
 #### Source code
 
-[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_2_0.ts#L116)
+[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
 
 ### createUserOperation
 
@@ -302,7 +302,7 @@ console.log(userOperation);
 </details>
 
 #### Source code
-[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_2_0.ts#L341)
+[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
 
 ### signUserOperation
 
@@ -348,7 +348,7 @@ console.log(signature);
 </details>
 
 #### Source code
-[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_2_0.ts#L479)
+[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
 
 ### sendUserOperation
 
@@ -424,7 +424,7 @@ receipt: {
 </details>
 
 #### Source code
-[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccount.ts#L993)
+[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts)
 
 ## Advanced Methods
 
@@ -478,7 +478,7 @@ Account address(sender) : 0x1a02592A3484c2077d2E5D24482497F85e1980C6
 
 #### Source code
 
-[createAccountAddress](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_2_0.ts#L76)
+[createAccountAddress](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
 
 ### createInitCode
 
@@ -527,7 +527,7 @@ initCode: 0x...
 
 #### Source code
 
-[createInitCode](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_2_0.ts#L307)
+[createInitCode](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
 
 ### createAccountAddressAndInitCode
 
@@ -579,7 +579,7 @@ initCode: 0x...
 
 #### Source code
 
-[createAccountAddressAndInitCode](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_2_0.ts#L251)
+[createAccountAddressAndInitCode](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
 
 ### createInitializerCallData
 
@@ -622,7 +622,7 @@ initializeCallData: 0xb63e800d00000000000000000000000000000000000000000000000000
 </details>
 
 #### Source code
-[createInitializerCallData](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_2_0.ts#L269)
+[createInitializerCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
 
 ### createAccountCallDataSingleTransaction
 
@@ -675,7 +675,7 @@ callData : 0xf34308ef000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2
 
 #### Source code
 
-[createAccountCallDataSingleTransaction](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccount.ts#L223)
+[createAccountCallDataSingleTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts)
 
 ### createAccountCallDataBatchTransactions
 
@@ -740,7 +740,7 @@ callData : 0xf34308ef000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2
 
 #### Source code
 
-[createAccountCallDataBatchTransactions](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccount.ts#L258)
+[createAccountCallDataBatchTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts)
 
 ### estimateUserOperationGas
 
@@ -810,7 +810,7 @@ const [preVerificationGas, verificationGasLimit, callGasLimit] = await estimateU
 </details>
 
 #### Source code
-[estimateUserOperationGas](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_2_0.ts#L444)
+[estimateUserOperationGas](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
 
 ### getUserOperationEip712Hash
 
@@ -847,7 +847,7 @@ console.log(safeUserOpHash);
 
 #### Source code
 
-[getUserOperationEip712Hash](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_2_0.ts#L176)
+[getUserOperationEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
 
 ### formatEip712SignaturesToUseroperationSignature
 
@@ -923,7 +923,7 @@ userOperation.signature = formatedSig;
 </details>
 
 #### Source code
-[formatEip712SignaturesToUseroperationSignature](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccount.ts#L486)
+[formatEip712SignaturesToUseroperationSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts)
 
 ### isModuleEnabled
 
@@ -1051,7 +1051,7 @@ const userOperation = await smartAccount.createUserOperation(
 
 #### Source code
 
-[createMigrateToSafeAccountV0_3_0MetaTransactions](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_2_0.ts#L387)
+[createMigrateToSafeAccountV0_3_0MetaTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
 
 ## Audits
 - [Audits by Ackee and OpenZeppelin](https://github.com/safe-global/safe-modules/blob/main/modules/4337/docs/v0.2.0/audit.md)

--- a/docs/wallet/abstractionkit/7-safe-account-v2.mdx
+++ b/docs/wallet/abstractionkit/7-safe-account-v2.mdx
@@ -114,7 +114,7 @@ const smartAccount = new SafeAccount(accountAddress);
 
 #### Source code
 
-[constructor](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
+[constructor](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts#L44)
 
 ## Methods
 
@@ -166,7 +166,7 @@ Account address(sender) : 0x1a02592A3484c2077d2E5D24482497F85e1980C6
 
 #### Source code
 
-[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
+[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts#L117)
 
 ### createUserOperation
 
@@ -302,7 +302,7 @@ console.log(userOperation);
 </details>
 
 #### Source code
-[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
+[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts#L342)
 
 ### signUserOperation
 
@@ -348,7 +348,7 @@ console.log(signature);
 </details>
 
 #### Source code
-[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
+[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts#L480)
 
 ### sendUserOperation
 
@@ -424,7 +424,7 @@ receipt: {
 </details>
 
 #### Source code
-[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts)
+[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts#L1006)
 
 ## Advanced Methods
 
@@ -478,7 +478,7 @@ Account address(sender) : 0x1a02592A3484c2077d2E5D24482497F85e1980C6
 
 #### Source code
 
-[createAccountAddress](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
+[createAccountAddress](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts#L77)
 
 ### createInitCode
 
@@ -527,7 +527,7 @@ initCode: 0x...
 
 #### Source code
 
-[createInitCode](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
+[createInitCode](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts#L308)
 
 ### createAccountAddressAndInitCode
 
@@ -579,7 +579,7 @@ initCode: 0x...
 
 #### Source code
 
-[createAccountAddressAndInitCode](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
+[createAccountAddressAndInitCode](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts#L252)
 
 ### createInitializerCallData
 
@@ -622,7 +622,7 @@ initializeCallData: 0xb63e800d00000000000000000000000000000000000000000000000000
 </details>
 
 #### Source code
-[createInitializerCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
+[createInitializerCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts#L270)
 
 ### createAccountCallDataSingleTransaction
 
@@ -675,7 +675,7 @@ callData : 0xf34308ef000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2
 
 #### Source code
 
-[createAccountCallDataSingleTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts)
+[createAccountCallDataSingleTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts#L227)
 
 ### createAccountCallDataBatchTransactions
 
@@ -740,7 +740,7 @@ callData : 0xf34308ef000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2
 
 #### Source code
 
-[createAccountCallDataBatchTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts)
+[createAccountCallDataBatchTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts#L262)
 
 ### estimateUserOperationGas
 
@@ -810,7 +810,7 @@ const [preVerificationGas, verificationGasLimit, callGasLimit] = await estimateU
 </details>
 
 #### Source code
-[estimateUserOperationGas](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
+[estimateUserOperationGas](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts#L445)
 
 ### getUserOperationEip712Hash
 
@@ -847,7 +847,7 @@ console.log(safeUserOpHash);
 
 #### Source code
 
-[getUserOperationEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
+[getUserOperationEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts#L177)
 
 ### formatEip712SignaturesToUseroperationSignature
 
@@ -923,7 +923,7 @@ userOperation.signature = formatedSig;
 </details>
 
 #### Source code
-[formatEip712SignaturesToUseroperationSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts)
+[formatEip712SignaturesToUseroperationSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts#L490)
 
 ### isModuleEnabled
 
@@ -1051,7 +1051,7 @@ const userOperation = await smartAccount.createUserOperation(
 
 #### Source code
 
-[createMigrateToSafeAccountV0_3_0MetaTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts)
+[createMigrateToSafeAccountV0_3_0MetaTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_2_0.ts#L388)
 
 ## Audits
 - [Audits by Ackee and OpenZeppelin](https://github.com/safe-global/safe-modules/blob/main/modules/4337/docs/v0.2.0/audit.md)

--- a/docs/wallet/abstractionkit/8-safe-account-v3.mdx
+++ b/docs/wallet/abstractionkit/8-safe-account-v3.mdx
@@ -133,7 +133,7 @@ Account address(sender) : 0x1a02592A3484c2077d2E5D24482497F85e1980C6
 
 #### Source code
 
-[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts)
+[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts#L106)
 
 ### createUserOperation
 
@@ -273,7 +273,7 @@ console.log(userOperation);
 </details>
 
 #### Source code
-[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts)
+[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts#L313)
 
 ### signUserOperation
 
@@ -321,7 +321,7 @@ console.log(signature);
 </details>
 
 #### Source code
-[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts)
+[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts#L384)
 
 ### sendUserOperation
 
@@ -397,7 +397,7 @@ receipt: {
 </details>
 
 #### Source code
-[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts)
+[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts#L1006)
 
 ## Advanced Methods
 
@@ -451,7 +451,7 @@ Account address(sender) : 0x1a02592A3484c2077d2E5D24482497F85e1980C6
 
 #### Source code
 
-[createAccountAddress](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts)
+[createAccountAddress](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts#L77)
 
 ### createFactoryAddressAndData
 
@@ -503,7 +503,7 @@ factoryData:  0x1688f0b900000000000000000000000029fcb43b46531bca003ddc8fcb67ffe9
 
 #### Source code
 
-[createFactoryAddressAndData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts)
+[createFactoryAddressAndData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts#L281)
 
 ### createInitializerCallData
 
@@ -546,7 +546,7 @@ initializeCallData: 0xb63e800d00000000000000000000000000000000000000000000000000
 </details>
 
 #### Source
-[createInitializerCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts)
+[createInitializerCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts#L243)
 
 ### createAccountCallDataSingleTransaction
 
@@ -599,7 +599,7 @@ callData : 0xf34308ef000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2
 
 #### Source code
 
-[createAccountCallDataSingleTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts)
+[createAccountCallDataSingleTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts#L227)
 
 ### createAccountCallDataBatchTransactions
 
@@ -664,7 +664,7 @@ callData : 0xf34308ef000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2
 
 #### Source code
 
-[createAccountCallDataBatchTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts)
+[createAccountCallDataBatchTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts#L262)
 
 ### estimateUserOperationGas
 
@@ -734,7 +734,7 @@ const [preVerificationGas, verificationGasLimit, callGasLimit] = await estimateU
 </details>
 
 #### Source code
-[estimateUserOperationGas](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts)
+[estimateUserOperationGas](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts#L349)
 
 ### getUserOperationEip712Hash
 
@@ -778,7 +778,7 @@ console.log(safeUserOpHash);
 </details>
 
 #### Source
-[getUserOperationEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts)
+[getUserOperationEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts#L166)
 
 ### formatEip712SignaturesToUseroperationSignature
 
@@ -854,7 +854,7 @@ userOperation.signature = formatedSig;
 </details>
 
 #### Source code
-[formatEip712SignaturesToUseroperationSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts)
+[formatEip712SignaturesToUseroperationSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts#L490)
 
 
 ### isModuleEnabled

--- a/docs/wallet/abstractionkit/8-safe-account-v3.mdx
+++ b/docs/wallet/abstractionkit/8-safe-account-v3.mdx
@@ -133,7 +133,7 @@ Account address(sender) : 0x1a02592A3484c2077d2E5D24482497F85e1980C6
 
 #### Source code
 
-[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_3_0.ts#L105)
+[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts)
 
 ### createUserOperation
 
@@ -273,7 +273,7 @@ console.log(userOperation);
 </details>
 
 #### Source code
-[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_3_0.ts#L312)
+[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts)
 
 ### signUserOperation
 
@@ -321,7 +321,7 @@ console.log(signature);
 </details>
 
 #### Source code
-[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_3_0.ts#L383)
+[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts)
 
 ### sendUserOperation
 
@@ -397,7 +397,7 @@ receipt: {
 </details>
 
 #### Source code
-[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccount.ts#L993)
+[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts)
 
 ## Advanced Methods
 
@@ -451,7 +451,7 @@ Account address(sender) : 0x1a02592A3484c2077d2E5D24482497F85e1980C6
 
 #### Source code
 
-[createAccountAddress](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_3_0.ts#L76)
+[createAccountAddress](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts)
 
 ### createFactoryAddressAndData
 
@@ -503,7 +503,7 @@ factoryData:  0x1688f0b900000000000000000000000029fcb43b46531bca003ddc8fcb67ffe9
 
 #### Source code
 
-[createFactoryAddressAndData](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_3_0.ts#L280)
+[createFactoryAddressAndData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts)
 
 ### createInitializerCallData
 
@@ -546,7 +546,7 @@ initializeCallData: 0xb63e800d00000000000000000000000000000000000000000000000000
 </details>
 
 #### Source
-[createInitializerCallData](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_3_0.ts#L242)
+[createInitializerCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts)
 
 ### createAccountCallDataSingleTransaction
 
@@ -599,7 +599,7 @@ callData : 0xf34308ef000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2
 
 #### Source code
 
-[createAccountCallDataSingleTransaction](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccount.ts#L223)
+[createAccountCallDataSingleTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts)
 
 ### createAccountCallDataBatchTransactions
 
@@ -664,7 +664,7 @@ callData : 0xf34308ef000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2
 
 #### Source code
 
-[createAccountCallDataBatchTransactions](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccount.ts#L258)
+[createAccountCallDataBatchTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts)
 
 ### estimateUserOperationGas
 
@@ -734,7 +734,7 @@ const [preVerificationGas, verificationGasLimit, callGasLimit] = await estimateU
 </details>
 
 #### Source code
-[estimateUserOperationGas](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_3_0.ts#L348)
+[estimateUserOperationGas](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts)
 
 ### getUserOperationEip712Hash
 
@@ -778,7 +778,7 @@ console.log(safeUserOpHash);
 </details>
 
 #### Source
-[getUserOperationEip712Hash](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccountV0_3_0.ts#L165)
+[getUserOperationEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccountV0_3_0.ts)
 
 ### formatEip712SignaturesToUseroperationSignature
 
@@ -854,7 +854,7 @@ userOperation.signature = formatedSig;
 </details>
 
 #### Source code
-[formatEip712SignaturesToUseroperationSignature](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccount.ts#L486)
+[formatEip712SignaturesToUseroperationSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts)
 
 
 ### isModuleEnabled

--- a/docs/wallet/guides/onchain-identifiers.mdx
+++ b/docs/wallet/guides/onchain-identifiers.mdx
@@ -32,7 +32,7 @@ const onchainIdentifier = smartAccount.onChainIdentifier
 
 The `onChainIdentifier` property contains the generated identifier and additional information about the tooling used.
 
-View the identifier generation in the [generateOnChainIdentifier](https://github.com/candidelabs/abstractionkit/blob/main/src/account/Safe/SafeAccount.ts#L2819) source code. 
+View the identifier generation in the [generateOnChainIdentifier](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts) source code. 
 
 <details>
 <summary>What's the format of the identifier?</summary>

--- a/docs/wallet/guides/onchain-identifiers.mdx
+++ b/docs/wallet/guides/onchain-identifiers.mdx
@@ -32,7 +32,7 @@ const onchainIdentifier = smartAccount.onChainIdentifier
 
 The `onChainIdentifier` property contains the generated identifier and additional information about the tooling used.
 
-View the identifier generation in the [generateOnChainIdentifier](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts) source code. 
+View the identifier generation in the [generateOnChainIdentifier](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts#L3354) source code. 
 
 <details>
 <summary>What's the format of the identifier?</summary>

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.6.3",
-    "tailwindcss": "^3.4.17"
+    "tailwindcss": "^3.4.17",
+    "typescript": "^6.0.3"
   },
   "browserslist": {
     "production": [

--- a/scripts/pin-source-links.mjs
+++ b/scripts/pin-source-links.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+// One-off: rewrite #L<n> anchors on abstractionkit/blob/v0.3.2 links to point
+// to the correct line of each symbol as it exists in the pinned tag.
+//
+// Strategy:
+//   1. Grep MDX files for links matching `[<symbol>](…abstractionkit/blob/v0.3.2/<path>#L<n>)`.
+//   2. For each unique <path>, fetch the file at v0.3.2 and parse with the TS
+//      compiler. Record line numbers for every MethodDeclaration,
+//      FunctionDeclaration, and ConstructorDeclaration, keyed by symbol name.
+//      Inside a file, a name may resolve to multiple lines — record them all.
+//   3. For each link, pick the correct line:
+//      - If the symbol has exactly one definition in the file, use it.
+//      - If it has multiple, prefer the one closest to the old line number.
+//   4. Print a report (old → new per link) and rewrite the MDX files.
+//
+// After running, manually eyeball the report before committing.
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
+import ts from "typescript";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..");
+const TAG = "v0.3.2";
+const CACHE = join(repoRoot, ".cache-abstractionkit-v0.3.2");
+
+mkdirSync(CACHE, { recursive: true });
+
+function fetchSource(path) {
+	const cachePath = join(CACHE, path.replaceAll("/", "__"));
+	if (existsSync(cachePath)) return readFileSync(cachePath, "utf8");
+	const raw = execSync(
+		`gh api repos/candidelabs/abstractionkit/contents/${path}?ref=${TAG} --jq .content`,
+		{ encoding: "utf8" },
+	);
+	const decoded = Buffer.from(raw.trim(), "base64").toString("utf8");
+	writeFileSync(cachePath, decoded);
+	return decoded;
+}
+
+function collectSymbolLines(source) {
+	// name -> sorted array of 1-based line numbers
+	const map = new Map();
+	const sf = ts.createSourceFile("x.ts", source, ts.ScriptTarget.Latest, true);
+
+	const record = (name, node) => {
+		if (!name) return;
+		const { line } = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+		const arr = map.get(name) ?? [];
+		arr.push(line + 1);
+		map.set(name, arr);
+	};
+
+	const visit = (node) => {
+		if (ts.isMethodDeclaration(node) && node.name) {
+			record(node.name.getText(sf), node);
+		} else if (ts.isFunctionDeclaration(node) && node.name) {
+			record(node.name.getText(sf), node);
+		} else if (ts.isConstructorDeclaration(node)) {
+			record("constructor", node);
+		} else if (ts.isPropertyDeclaration(node) && node.name && node.initializer &&
+			(ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer))) {
+			record(node.name.getText(sf), node);
+		} else if (ts.isVariableStatement(node)) {
+			for (const decl of node.declarationList.declarations) {
+				if (decl.initializer &&
+					(ts.isArrowFunction(decl.initializer) || ts.isFunctionExpression(decl.initializer))) {
+					record(decl.name.getText(sf), decl);
+				}
+			}
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(sf);
+	for (const arr of map.values()) arr.sort((a, b) => a - b);
+	return map;
+}
+
+const LINK_RE =
+	/\[([A-Za-z_][\w]*)\]\((https:\/\/github\.com\/candidelabs\/abstractionkit\/blob\/v0\.3\.2\/([^)#\s"]+))#L(\d+)\)/g;
+
+const mdxFiles = execSync(
+	`grep -rl "abstractionkit/blob/v0.3.2" --include="*.mdx" --include="*.md" docs/`,
+	{ encoding: "utf8", cwd: repoRoot },
+).trim().split("\n").filter(Boolean);
+
+// Pass 1: collect all referenced (path, symbol, oldLine)
+const symbolMapByPath = new Map();
+const report = []; // {file, symbol, path, oldLine, newLine, note}
+
+for (const rel of mdxFiles) {
+	const full = join(repoRoot, rel);
+	const text = readFileSync(full, "utf8");
+	for (const m of text.matchAll(LINK_RE)) {
+		const [, symbol, , path, oldLineStr] = m;
+		if (!symbolMapByPath.has(path)) {
+			const source = fetchSource(path);
+			symbolMapByPath.set(path, collectSymbolLines(source));
+		}
+	}
+}
+
+// Pass 2: rewrite
+for (const rel of mdxFiles) {
+	const full = join(repoRoot, rel);
+	const text = readFileSync(full, "utf8");
+	const updated = text.replace(LINK_RE, (match, symbol, urlBase, path, oldLineStr) => {
+		const oldLine = Number(oldLineStr);
+		const candidates = symbolMapByPath.get(path)?.get(symbol);
+		if (!candidates || candidates.length === 0) {
+			report.push({ file: rel, symbol, path, oldLine, newLine: null, note: "NOT FOUND" });
+			return match;
+		}
+		let newLine, note;
+		if (candidates.length === 1) {
+			[newLine] = candidates;
+			note = "unique";
+		} else {
+			newLine = candidates.reduce((best, c) =>
+				Math.abs(c - oldLine) < Math.abs(best - oldLine) ? c : best, candidates[0]);
+			note = `ambiguous (${candidates.length}): ${candidates.join(",")} → closest to ${oldLine}`;
+		}
+		report.push({ file: rel, symbol, path, oldLine, newLine, note });
+		return `[${symbol}](${urlBase}#L${newLine})`;
+	});
+	if (updated !== text) writeFileSync(full, updated);
+}
+
+// Report
+console.log("file\tsymbol\tpath\told→new\tnote");
+for (const r of report) {
+	console.log(
+		`${r.file}\t${r.symbol}\t${r.path}\t${r.oldLine}→${r.newLine ?? "—"}\t${r.note}`,
+	);
+}
+console.log(`\nTotal: ${report.length} links`);
+const notFound = report.filter((r) => r.newLine === null);
+const ambiguous = report.filter((r) => r.note.startsWith("ambiguous"));
+const changed = report.filter((r) => r.newLine !== null && r.newLine !== r.oldLine);
+console.log(`  unique matches: ${report.length - notFound.length - ambiguous.length}`);
+console.log(`  ambiguous (resolved by proximity): ${ambiguous.length}`);
+console.log(`  not found: ${notFound.length}`);
+console.log(`  line number changed: ${changed.length}`);

--- a/scripts/pin-source-links.mjs
+++ b/scripts/pin-source-links.mjs
@@ -18,7 +18,7 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 import ts from "typescript";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -31,8 +31,9 @@ mkdirSync(CACHE, { recursive: true });
 function fetchSource(path) {
 	const cachePath = join(CACHE, path.replaceAll("/", "__"));
 	if (existsSync(cachePath)) return readFileSync(cachePath, "utf8");
-	const raw = execSync(
-		`gh api repos/candidelabs/abstractionkit/contents/${path}?ref=${TAG} --jq .content`,
+	const raw = execFileSync(
+		"gh",
+		["api", `repos/candidelabs/abstractionkit/contents/${path}?ref=${TAG}`, "--jq", ".content"],
 		{ encoding: "utf8" },
 	);
 	const decoded = Buffer.from(raw.trim(), "base64").toString("utf8");
@@ -81,10 +82,16 @@ function collectSymbolLines(source) {
 const LINK_RE =
 	/\[([A-Za-z_][\w]*)\]\((https:\/\/github\.com\/candidelabs\/abstractionkit\/blob\/v0\.3\.2\/([^)#\s"]+))#L(\d+)\)/g;
 
-const mdxFiles = execSync(
-	`grep -rl "abstractionkit/blob/v0.3.2" --include="*.mdx" --include="*.md" docs/`,
-	{ encoding: "utf8", cwd: repoRoot },
-).trim().split("\n").filter(Boolean);
+let mdxFiles;
+try {
+	mdxFiles = execSync(
+		`grep -rl "abstractionkit/blob/v0.3.2" --include="*.mdx" --include="*.md" docs/`,
+		{ encoding: "utf8", cwd: repoRoot },
+	).trim().split("\n").filter(Boolean);
+} catch (err) {
+	if (err.status === 1) mdxFiles = []; // no matches — release bump no-op
+	else throw err;
+}
 
 // Pass 1: collect all referenced (path, symbol, oldLine)
 const symbolMapByPath = new Map();

--- a/yarn.lock
+++ b/yarn.lock
@@ -10611,6 +10611,11 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
+typescript@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
+
 ufo@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.5.4.tgz#16d6949674ca0c9e0fbbae1fa20a71d7b1ded754"


### PR DESCRIPTION
## Summary
- Pinned all 93 AbstractionKit source links from `blob/main` to `blob/v0.3.2` across 7 docs files
- Stripped `#L<n>` line anchors — they decay within a pinned tag whenever the docs aren't re-audited per release; the function name in the link text keeps the target findable

## Why
Flagged in #34 review: unpinned source links silently rot as the SDK evolves. Pinning gives readers (and AI agents reading the docs) a ground-truth anchor matching the shipped API. Dropping line anchors removes the most decay-prone piece so patch releases don't invalidate links.

## Out of scope
These other repos still use `blob/main` and can be pinned in follow-ups once their release strategy is decided:
- `CandideWalletContracts`
- `abstractionkit-examples`
- `safe-4337-multi-chain-signature-module`
- `safe-recovery-service-sdk`

## Release bump workflow
On each AbstractionKit release, one find/replace updates every link:
```
grep -rl "abstractionkit/blob/v0.3.2" docs | xargs sed -i 's|v0.3.2|vX.Y.Z|g'
```

Closes #35

## Test plan
- [x] `yarn build` succeeds
- [x] Sample URL `abstractionkit/blob/v0.3.2/src/account/Safe/SafeAccount.ts` resolves at the pinned tag
- [ ] Reviewer spot-checks a few links in the rendered preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Pinned many “Source code” hyperlinks in wallet guides and reference pages to the stable v0.3.2 release (updated linked line anchors where applicable).

* **Chores**
  * Added a CLI utility to automate pinning/updating documentation source-link anchors.
  * Development metadata updated (TypeScript dev dependency added).
  * .gitignore extended to exclude local worktree and cache artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->