### PR TITLE
chore: drop direct clsx dependency, inline 1-line helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@mdx-js/react": "3.1.0",
     "@saucelabs/theme-github-codeblock": "^0.3.0",
     "@signalwire/docusaurus-plugin-llms-txt": "^1.2.2",
-    "clsx": "^2.1.1",
     "docusaurus-lunr-search": "^3.6.0",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.0.0",

--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Link from '@docusaurus/Link'
-import clsx from 'clsx'
+
+const cx = (...args) => args.filter(Boolean).join(' ')
 
 export default function CardList({ items }) {
     return (
@@ -13,7 +14,7 @@ export default function CardList({ items }) {
 }
 
 function Card({ title, description, route }) {
-    const rootElClassName = clsx(
+    const rootElClassName = cx(
         'block relative rounded-lg p-4 hover:no-underline group w-full',
         'border transition-all duration-150',
         'dark:bg-[rgba(255,255,255,0.03)] bg-white',


### PR DESCRIPTION
## Summary
- Only \`src/components/CardList.js\` imported \`clsx\`, and only for string/false args. Replace with a one-line \`filter(Boolean).join(' ')\` helper.
- Remove \`clsx\` from \`package.json\` direct dependencies. It remains as a transitive dep of Docusaurus, so \`yarn.lock\` is unchanged.

## Why
Part of the supply-chain hardening pass. \`clsx\` is a solo-maintainer package (lukeed) with no commits since June 2024. The code is trivial enough to inline, so we no longer sit directly on that package's publish pipeline.

## Test plan
- [ ] Verify \`CardList\` still renders correctly on any page that uses it (e.g. doc index pages)
- [ ] \`yarn build\` passes (verified locally: 25s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced an external CSS utility dependency with an internal helper function, reducing external dependencies while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->