### PR TITLE
docs: update Calibur docs for v0.3.2 method renames

### DIFF
--- a/docs/wallet/abstractionkit/12-calibur-account.mdx
+++ b/docs/wallet/abstractionkit/12-calibur-account.mdx
@@ -50,10 +50,10 @@ import {
   getKeySettingsReturn,
   getKeyParam,
   getKeyReturn,
-  listKeysParam,
-  listKeysReturn,
-  isDelegatedParam,
-  isDelegatedReturn,
+  getKeysParam,
+  getKeysReturn,
+  isDelegatedToThisAccountParam,
+  isDelegatedToThisAccountReturn,
   getNonceParam,
   getNonceReturn,
   createAccountCallDataParam,
@@ -831,15 +831,15 @@ console.log("Public key:", key.publicKey);
 #### Source code
 [getKey](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L1228)
 
-### listKeys
+### getKeys
 
-Lists all keys registered on this account. Iterates `keyCount()` and `keyAt(i)` to enumerate all keys.
+Returns all keys registered on this account. Iterates `keyCount()` and `keyAt(i)` to enumerate all keys.
 
 <Tabs>
 <TabItem value="example.ts" label="example.ts">
 
 ```ts title="example.ts"
-const keys = await smartAccount.listKeys(
+const keys = await smartAccount.getKeys(
   "https://ethereum-sepolia-rpc.publicnode.com",
 );
 
@@ -855,19 +855,19 @@ for (const key of keys) {
 </TabItem>
 
 <TabItem value="Param Types" label="Param Types">
-  <DataTable items={listKeysParam} />
+  <DataTable items={getKeysParam} />
 </TabItem>
 
 <TabItem value="Return Type" label="Return Type">
-  <DataTable items={listKeysReturn} />
+  <DataTable items={getKeysReturn} />
 </TabItem>
 
 </Tabs>
 
 #### Source code
-[listKeys](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L1059)
+[getKeys](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L1275)
 
-### isDelegated
+### isDelegatedToThisAccount
 
 Checks if the EOA is delegated to this account's Calibur singleton. Returns `true` only when delegated to the account's `delegateeAddress`, `false` if not delegated or delegated to a different singleton.
 
@@ -875,7 +875,7 @@ Checks if the EOA is delegated to this account's Calibur singleton. Returns `tru
 <TabItem value="example.ts" label="example.ts">
 
 ```ts title="example.ts"
-const isDelegated = await smartAccount.isDelegated(
+const isDelegated = await smartAccount.isDelegatedToThisAccount(
   "https://ethereum-sepolia-rpc.publicnode.com"
 );
 
@@ -889,17 +889,17 @@ if (isDelegated) {
 </TabItem>
 
 <TabItem value="Param Types" label="Param Types">
-  <DataTable items={isDelegatedParam} />
+  <DataTable items={isDelegatedToThisAccountParam} />
 </TabItem>
 
 <TabItem value="Return Type" label="Return Type">
-  <DataTable items={isDelegatedReturn} />
+  <DataTable items={isDelegatedToThisAccountReturn} />
 </TabItem>
 
 </Tabs>
 
 #### Source code
-[isDelegated](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L903)
+[isDelegatedToThisAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.2/src/account/Calibur/Calibur7702Account.ts#L1116)
 
 ### getNonce
 

--- a/docs/wallet/guides/10-getting-started-calibur.mdx
+++ b/docs/wallet/guides/10-getting-started-calibur.mdx
@@ -81,7 +81,7 @@ const smartAccount = new Calibur7702Account(eoaAddress);
 console.log("Smart account address: " + smartAccount.accountAddress);
 
 // Check if the EOA is already delegated to Calibur
-const alreadyDelegated = await smartAccount.isDelegated(nodeUrl);
+const alreadyDelegated = await smartAccount.isDelegatedToThisAccount(nodeUrl);
 
 // CandidePaymaster sponsors gas so the EOA doesn't need native tokens.
 const paymaster = new CandidePaymaster(paymasterUrl);

--- a/docs/wallet/guides/11-calibur-passkeys.mdx
+++ b/docs/wallet/guides/11-calibur-passkeys.mdx
@@ -70,8 +70,8 @@ const smartAccount = new Calibur7702Account(eoaAddress);
 const paymaster = new CandidePaymaster(paymasterUrl);
 
 // Check if the EOA is already delegated to Calibur.
-// isDelegated() returns true only if delegated to this account's delegateeAddress.
-const alreadyDelegated = await smartAccount.isDelegated(nodeUrl);
+// isDelegatedToThisAccount() returns true only if delegated to this account's delegateeAddress.
+const alreadyDelegated = await smartAccount.isDelegatedToThisAccount(nodeUrl);
 console.log("Already delegated:", alreadyDelegated);
 ```
 

--- a/docs/wallet/guides/12-calibur-key-management.mdx
+++ b/docs/wallet/guides/12-calibur-key-management.mdx
@@ -66,7 +66,7 @@ const smartAccount = new Calibur7702Account(eoaAddress);
 const paymaster = new CandidePaymaster(paymasterUrl);
 
 // This guide requires an already-delegated account.
-const delegated = await smartAccount.isDelegated(nodeUrl);
+const delegated = await smartAccount.isDelegatedToThisAccount(nodeUrl);
 if (!delegated) {
     console.log("EOA is not yet delegated to Calibur. Run the quickstart first.");
     process.exit(1);
@@ -82,7 +82,7 @@ const keyTypeNames = {
     [CaliburKeyType.Secp256k1]: "Secp256k1",
 };
 
-const keys = await smartAccount.listKeys(nodeUrl);
+const keys = await smartAccount.getKeys(nodeUrl);
 console.log("Registered keys:\n");
 
 for (const key of keys) {
@@ -98,7 +98,7 @@ for (const key of keys) {
 }
 ```
 
-`listKeys` returns all currently registered keys. `getKeySettings` returns a key's expiration timestamp, hook address, and admin flag.
+`getKeys` returns all currently registered keys. `getKeySettings` returns a key's expiration timestamp, hook address, and admin flag.
 
 Run the code to verify:
 

--- a/src/data/caliburAccountParams.ts
+++ b/src/data/caliburAccountParams.ts
@@ -670,8 +670,8 @@ export const getKeyReturn = [
   },
 ];
 
-// listKeys
-export const listKeysParam = [
+// getKeys
+export const getKeysParam = [
   {
     key: "providerRpc",
     type: "string",
@@ -679,7 +679,7 @@ export const listKeysParam = [
   },
 ];
 
-export const listKeysReturn = [
+export const getKeysReturn = [
   {
     key: "keys",
     type: "CaliburKey[]",
@@ -687,8 +687,8 @@ export const listKeysReturn = [
   },
 ];
 
-// isDelegated
-export const isDelegatedParam = [
+// isDelegatedToThisAccount
+export const isDelegatedToThisAccountParam = [
   {
     key: "providerRpc",
     type: "string",
@@ -696,7 +696,7 @@ export const isDelegatedParam = [
   },
 ];
 
-export const isDelegatedReturn = [
+export const isDelegatedToThisAccountReturn = [
   {
     key: "isDelegated",
     type: "boolean",


### PR DESCRIPTION
## Summary
- `listKeys` → `getKeys`
- `isDelegated` → `isDelegatedToThisAccount`

These methods were renamed in AbstractionKit v0.3.2 but the docs still referenced them under their old names (surfaced during the link-pinning audit in #36).

## Scope
- `docs/wallet/abstractionkit/12-calibur-account.mdx` — section headers, code examples, DataTable references, pinned source links (correct v0.3.2 lines: `getKeys` L1275, `isDelegatedToThisAccount` L1116)
- Calibur guides (`10-getting-started`, `11-passkeys`, `12-key-management`) — call sites and one prose line
- `src/data/caliburAccountParams.ts` — renamed the four corresponding table-data exports

No other docs touched: Simple7702 docs already use `isDelegatedToThisAccount`; shared EIP-7702 page uses `isDelegated` only as a local variable name.

Closes #37

## Test plan
- [x] `yarn build` succeeds
- [x] No remaining `.isDelegated(` or `listKeys` references across docs and Calibur data (verified via grep)
- [ ] Reviewer spot-checks the rendered Calibur method reference page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated method naming conventions in guides and documentation for key management and delegation checks.
  * All quickstart examples and code samples updated to reflect the latest API method names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->