### PR TITLE
docs: add External Signers reference

### DIFF
--- a/docs/wallet/abstractionkit/10-simple-7702-account-v09.mdx
+++ b/docs/wallet/abstractionkit/10-simple-7702-account-v09.mdx
@@ -180,7 +180,7 @@ userOperation.signature = signature;
 
 ### signUserOperationWithSigner
 
-Signs a UserOperation using an [`ExternalSigner`](/wallet/guides/authentication#external-signers) instead of a raw private key. Integrates viem, ethers, browser wallets, hardware wallets, HSMs, and MPC services through the same API.
+Signs a UserOperation using an [`ExternalSigner`](/wallet/abstractionkit/external-signers) instead of a raw private key. Integrates viem, ethers, browser wallets, hardware wallets, HSMs, and MPC services through the same API.
 
 Since AbstractionKit `v0.3.5`, `Simple7702AccountV09` accepts signers that implement either `signTypedData` or `signHash`. The SDK prefers `signTypedData` when available, so JSON-RPC wallets and viem `WalletClient` instances can sign EntryPoint v0.9 UserOperations without raw-hash signing support. Raw-hash signers continue to work.
 
@@ -204,7 +204,7 @@ userOperation.signature = await smartAccount.signUserOperationWithSigner(
 );
 ```
 
-See [External Signers](/wallet/guides/authentication#external-signers) for the full list of adapters and custom-signer integrations. EntryPoint v0.9 also supports parallel paymaster signing via the two-phase `signingPhase` context — see the [v0.9 external-signer example](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/06-external-signer-v09.ts).
+See [External Signers](/wallet/abstractionkit/external-signers) for the full list of adapters and custom-signer integrations. EntryPoint v0.9 also supports parallel paymaster signing via the two-phase `signingPhase` context — see the [v0.9 external-signer example](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/06-external-signer-v09.ts).
 
 ### getUserOperationEip712TypedData
 

--- a/docs/wallet/abstractionkit/11-simple-7702-account-v08.mdx
+++ b/docs/wallet/abstractionkit/11-simple-7702-account-v08.mdx
@@ -180,7 +180,7 @@ userOperation.signature = signature;
 
 ### signUserOperationWithSigner
 
-Signs a UserOperation using an [`ExternalSigner`](/wallet/guides/authentication#external-signers) instead of a raw private key. Integrates viem, ethers, browser wallets, hardware wallets, HSMs, and MPC services through the same API.
+Signs a UserOperation using an [`ExternalSigner`](/wallet/abstractionkit/external-signers) instead of a raw private key. Integrates viem, ethers, browser wallets, hardware wallets, HSMs, and MPC services through the same API.
 
 Since AbstractionKit `v0.3.5`, `Simple7702Account` accepts signers that implement either `signTypedData` or `signHash`. The SDK prefers `signTypedData` when available, so JSON-RPC wallets and viem `WalletClient` instances can sign EntryPoint v0.8 UserOperations without raw-hash signing support. Raw-hash signers continue to work.
 
@@ -201,7 +201,7 @@ userOperation.signature = await smartAccount.signUserOperationWithSigner(
 );
 ```
 
-See [External Signers](/wallet/guides/authentication#external-signers) for the full list of adapters and custom-signer integrations.
+See [External Signers](/wallet/abstractionkit/external-signers) for the full list of adapters and custom-signer integrations.
 
 ### getUserOperationEip712TypedData
 

--- a/docs/wallet/abstractionkit/12-calibur-account.mdx
+++ b/docs/wallet/abstractionkit/12-calibur-account.mdx
@@ -255,7 +255,7 @@ userOperation.signature = smartAccount.signUserOperation(
 
 ### signUserOperationWithSigner
 
-Signs a UserOperation using an [`ExternalSigner`](/wallet/guides/authentication#external-signers) instead of a raw private key. Integrates viem, ethers, hardware wallets, HSMs, MPC, and WebAuthn through the same API. By default signs with the root key; pass `{ keyHash }` to sign with a registered secondary key.
+Signs a UserOperation using an [`ExternalSigner`](/wallet/abstractionkit/external-signers) instead of a raw private key. Integrates viem, ethers, hardware wallets, HSMs, MPC, and WebAuthn through the same API. By default signs with the root key; pass `{ keyHash }` to sign with a registered secondary key.
 
 Calibur requires a signer that implements `signHash` (raw 32-byte hash, no EIP-191 prefix). Signers that only expose `signTypedData` (e.g. a viem `WalletClient` via `fromViemWalletClient`) fail offline with an actionable error.
 
@@ -284,7 +284,7 @@ userOperation.signature = await smartAccount.signUserOperationWithSigner(
 );
 ```
 
-See [External Signers](/wallet/guides/authentication#external-signers) for the full list of adapters (viem, ethers, custom) and the [Calibur external-signer example](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/calibur-account/04-external-signer.ts) for a full end-to-end flow.
+See [External Signers](/wallet/abstractionkit/external-signers) for the full list of adapters (viem, ethers, custom) and the [Calibur external-signer example](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/calibur-account/04-external-signer.ts) for a full end-to-end flow.
 
 </TabItem>
 

--- a/docs/wallet/abstractionkit/13-safe-unified-account.mdx
+++ b/docs/wallet/abstractionkit/13-safe-unified-account.mdx
@@ -87,7 +87,7 @@ console.log("Account address (sender): " + smartAccount.accountAddress);
 
 #### Source code
 
-[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.5/src/account/Safe/SafeMultiChainSigAccount.ts)
+[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.7/src/account/Safe/SafeMultiChainSigAccount.ts)
 
 ### createUserOperation
 
@@ -129,7 +129,7 @@ const userOperation = await smartAccount.createUserOperation(
 
 #### Source code
 
-[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.5/src/account/Safe/SafeMultiChainSigAccount.ts)
+[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.7/src/account/Safe/SafeMultiChainSigAccount.ts)
 
 ### signUserOperations
 
@@ -182,7 +182,7 @@ userOp2.signature = signatures[1];
 
 #### Source code
 
-[signUserOperations](https://github.com/candidelabs/abstractionkit/blob/v0.3.5/src/account/Safe/SafeMultiChainSigAccount.ts)
+[signUserOperations](https://github.com/candidelabs/abstractionkit/blob/v0.3.7/src/account/Safe/SafeMultiChainSigAccount.ts)
 
 ### signUserOperationsWithSigners
 
@@ -244,7 +244,7 @@ const hash = SafeAccount.getMultiChainSingleSignatureUserOperationsEip712Hash([
 
 #### Source code
 
-[getMultiChainSingleSignatureUserOperationsEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.3.5/src/account/Safe/SafeMultiChainSigAccount.ts)
+[getMultiChainSingleSignatureUserOperationsEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.3.7/src/account/Safe/SafeMultiChainSigAccount.ts)
 
 ### getMultiChainSingleSignatureUserOperationsEip712Data
 
@@ -283,7 +283,7 @@ const signature = await wallet.signTypedData(domain, types, messageValue);
 
 #### Source code
 
-[getMultiChainSingleSignatureUserOperationsEip712Data](https://github.com/candidelabs/abstractionkit/blob/v0.3.5/src/account/Safe/SafeMultiChainSigAccount.ts)
+[getMultiChainSingleSignatureUserOperationsEip712Data](https://github.com/candidelabs/abstractionkit/blob/v0.3.7/src/account/Safe/SafeMultiChainSigAccount.ts)
 
 ### formatSignaturesToUseroperationsSignatures
 
@@ -337,7 +337,7 @@ userOp2.signature = signatures[1];
 
 #### Source code
 
-[formatSignaturesToUseroperationsSignatures](https://github.com/candidelabs/abstractionkit/blob/v0.3.5/src/account/Safe/SafeMultiChainSigAccount.ts)
+[formatSignaturesToUseroperationsSignatures](https://github.com/candidelabs/abstractionkit/blob/v0.3.7/src/account/Safe/SafeMultiChainSigAccount.ts)
 
 ### sendUserOperation
 

--- a/docs/wallet/abstractionkit/13-safe-unified-account.mdx
+++ b/docs/wallet/abstractionkit/13-safe-unified-account.mdx
@@ -186,7 +186,7 @@ userOp2.signature = signatures[1];
 
 ### signUserOperationsWithSigners
 
-Multi-op variant that signs a Merkle-rooted bundle of UserOperations using one or more [`ExternalSigner`s](/wallet/guides/authentication#external-signers) instead of raw private keys. One signing session covers every chain in the bundle.
+Multi-op variant that signs a Merkle-rooted bundle of UserOperations using one or more [`ExternalSigner`s](/wallet/abstractionkit/external-signers) instead of raw private keys. One signing session covers every chain in the bundle.
 
 The Merkle root has no typed-data display, so this path requires a signer that implements `signHash`. `fromViemWalletClient` (typed-data only) fails offline here; use `fromViem`, `fromEthersWallet`, or a custom signer.
 
@@ -209,7 +209,7 @@ userOp1.signature = signatures[0];
 userOp2.signature = signatures[1];
 ```
 
-See [External Signers](/wallet/guides/authentication#external-signers) for the full list of adapters, and the [multi-chain add-owner example](https://github.com/candidelabs/abstractionkit-examples/blob/main/chain-abstraction/add-owner-with-external-signer.ts) for a full end-to-end flow.
+See [External Signers](/wallet/abstractionkit/external-signers) for the full list of adapters, and the [multi-chain add-owner example](https://github.com/candidelabs/abstractionkit-examples/blob/main/chain-abstraction/add-owner-with-external-signer.ts) for a full end-to-end flow.
 
 ### getMultiChainSingleSignatureUserOperationsEip712Hash
 

--- a/docs/wallet/abstractionkit/14-external-signers.mdx
+++ b/docs/wallet/abstractionkit/14-external-signers.mdx
@@ -1,0 +1,262 @@
+---
+title: External Signers
+description: Agent-oriented reference for using ExternalSigner adapters with AbstractionKit accounts
+keywords: [external-signer, signer-adapter, viem, ethers, webauthn, mpc, hsm, passkeys, abstractionkit]
+---
+
+# External Signers
+
+`ExternalSigner` is the AbstractionKit interface for signing UserOperations with wallets, local accounts, passkeys, hardware wallets, HSMs, MPC services, or custom signing backends without passing raw private keys into account methods.
+
+Use this page as the implementation source for signer selection. If you are an AI agent, follow the workflow below before writing code.
+
+## Agent workflow
+
+### 1. Identify the account type
+
+Pick the signing method from the account class, not from the signer library.
+
+| Account type | Method to call | Signer parameter |
+|---|---|---|
+| Safe accounts (`SafeAccountV0_2_0`, `SafeAccountV0_3_0`, `SafeAccountV1_5_0_M_0_3_0`) | `signUserOperationWithSigners(userOperation, signers, chainId)` | array of `ExternalSigner` |
+| `SafeMultiChainSigAccountV1` single UserOperation | `signUserOperationWithSigners(userOperation, signers, chainId)` | array of `ExternalSigner` |
+| `SafeMultiChainSigAccountV1` multi-op Merkle path | `signUserOperationsWithSigners(userOperationsToSign, signers)` | array of `ExternalSigner` |
+| `Simple7702Account`, `Simple7702AccountV09` | `signUserOperationWithSigner(userOperation, signer, chainId)` | single `ExternalSigner` |
+| `Calibur7702Account` | `signUserOperationWithSigner(userOperation, signer, chainId)` | single `ExternalSigner` |
+
+### 2. Check the signing capability
+
+Every signer must provide `signHash`, `signTypedData`, or both. AbstractionKit negotiates the best supported scheme for the account.
+
+| Account path | Accepted schemes | Agent rule |
+|---|---|---|
+| Safe accounts | `typedData`, `hash` | Prefer signers that can show EIP-712 typed data when available. |
+| `SafeMultiChainSigAccountV1` single UserOperation | `typedData`, `hash` | Same as Safe accounts. |
+| `SafeMultiChainSigAccountV1` multi-op Merkle path | `hash` only | Use a hash-capable signer. Do not use `fromViemWalletClient`. |
+| `Simple7702Account`, `Simple7702AccountV09` | `typedData`, `hash` | JSON-RPC wallets can use typed data on EntryPoint v0.8/v0.9; hash-capable signers also work. |
+| `Calibur7702Account` | `hash` only | Use `fromViem`, `fromEthersWallet`, `fromPrivateKey`, or a custom signer with `signHash`. |
+
+Capability mismatches throw offline before any wallet prompt is shown. If code fails with a signing scheme error, change the adapter or account path instead of retrying the same signer.
+
+### 3. Pick the adapter
+
+| Signing source | Adapter | Provides | Use when |
+|---|---|---|---|
+| Raw private key string | `fromPrivateKey(privateKey)` | `signHash`, `signTypedData` | You need a private key to flow through the async `ExternalSigner` API. |
+| viem local account | `fromViem(localAccount)` | `signHash`, `signTypedData` | You have a viem `LocalAccount`, such as `privateKeyToAccount(pk)`. |
+| viem WalletClient | `fromViemWalletClient(client)` | `signTypedData` only | You use a browser or injected JSON-RPC wallet with Safe or Simple7702 typed-data signing. |
+| ethers Wallet / HDNodeWallet | `fromEthersWallet(wallet)` | `signHash`, `signTypedData` | The project already uses ethers v6 wallet instances. |
+| HSM, MPC, hardware wallet, remote signer | custom `ExternalSigner` | whatever you implement | The signer service exposes hash signing, typed-data signing, or both. |
+| Safe passkey owner | `fromSafeWebauthn(params)` | `signHash`, `type: "contract"` | You are signing a Safe UserOperation with a WebAuthn/passkey owner. |
+
+Do not add viem to a project that already uses ethers just for signing, or ethers to a project that already uses viem. Use the adapter that matches the existing stack.
+
+### 4. Sign and assign the signature
+
+The result of `signUserOperationWithSigner(s)` is already formatted for the account. Assign it directly to `userOperation.signature`.
+
+```ts
+userOperation.signature = await account.signUserOperationWithSigner(
+  userOperation,
+  signer,
+  chainId,
+);
+```
+
+For Safe accounts, pass one signer per owner required by the threshold:
+
+```ts
+userOperation.signature = await safe.signUserOperationWithSigners(
+  userOperation,
+  [signer],
+  chainId,
+);
+```
+
+For multi-chain Safe signing, pass the UserOperations and chain IDs together:
+
+```ts
+const signatures = await safe.signUserOperationsWithSigners(
+  [
+    { userOperation: op1, chainId: 11155111n },
+    { userOperation: op2, chainId: 84532n },
+  ],
+  [signer],
+);
+```
+
+## Adapter recipes
+
+### Raw private key
+
+Use this when the codebase wants all signers to share the async `ExternalSigner` path. For a simple single-owner private-key script, the legacy sync `signUserOperation(userOperation, [privateKey], chainId)` API is still shorter.
+
+```ts
+import { fromPrivateKey } from "abstractionkit";
+
+const signer = fromPrivateKey(process.env.PRIVATE_KEY as `0x${string}`);
+
+userOperation.signature = await safe.signUserOperationWithSigners(
+  userOperation,
+  [signer],
+  chainId,
+);
+```
+
+### viem local account
+
+Use `fromViem` with viem `LocalAccount` objects. This is the preferred viem adapter for scripts, backends, and local private-key accounts because it supports both hash and typed-data signing.
+
+```ts
+import { SafeAccountV0_3_0 as SafeAccount, fromViem } from "abstractionkit";
+import { privateKeyToAccount } from "viem/accounts";
+
+const localAccount = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`);
+const signer = fromViem(localAccount);
+
+const safe = SafeAccount.initializeNewAccount([signer.address]);
+userOperation.signature = await safe.signUserOperationWithSigners(
+  userOperation,
+  [signer],
+  chainId,
+);
+```
+
+Full example: [`signer/fromViem.ts`](https://github.com/candidelabs/abstractionkit-examples/blob/main/signer/fromViem.ts).
+
+### viem WalletClient
+
+Use `fromViemWalletClient` for browser wallets and injected JSON-RPC wallets. It only exposes `signTypedData`, so do not use it for Calibur or the Safe multi-op Merkle path.
+
+```ts
+import { SafeAccountV0_3_0 as SafeAccount, fromViemWalletClient } from "abstractionkit";
+import { createWalletClient, custom } from "viem";
+
+const walletClient = createWalletClient({
+  account: userAddress,
+  transport: custom(window.ethereum),
+});
+
+const signer = fromViemWalletClient(walletClient);
+
+const safe = SafeAccount.initializeNewAccount([signer.address]);
+userOperation.signature = await safe.signUserOperationWithSigners(
+  userOperation,
+  [signer],
+  chainId,
+);
+```
+
+Full example: [`signer/fromViemWalletClient.ts`](https://github.com/candidelabs/abstractionkit-examples/blob/main/signer/fromViemWalletClient.ts).
+
+### ethers Wallet
+
+Use `fromEthersWallet` when the project already uses ethers v6.
+
+```ts
+import { SafeAccountV0_3_0 as SafeAccount, fromEthersWallet } from "abstractionkit";
+import { Wallet } from "ethers";
+
+const wallet = new Wallet(process.env.PRIVATE_KEY as string);
+const signer = fromEthersWallet(wallet);
+
+const safe = SafeAccount.initializeNewAccount([signer.address]);
+userOperation.signature = await safe.signUserOperationWithSigners(
+  userOperation,
+  [signer],
+  chainId,
+);
+```
+
+Full example: [`signer/fromEthersWallet.ts`](https://github.com/candidelabs/abstractionkit-examples/blob/main/signer/fromEthersWallet.ts).
+
+### Custom signer
+
+Use a custom `ExternalSigner` for HSMs, MPC providers, hardware wallets, secure enclaves, or remote signing APIs. Implement the capability your account path needs.
+
+```ts
+import type { ExternalSigner } from "abstractionkit";
+
+const signer: ExternalSigner = {
+  address: deviceAddress as `0x${string}`,
+  signHash: async (hash) => {
+    const signature = await hsmClient.signHash(hash);
+    return signature as `0x${string}`;
+  },
+  signTypedData: async (typedData) => {
+    const signature = await mpcClient.signTypedData(typedData);
+    return signature as `0x${string}`;
+  },
+};
+```
+
+If the service only supports one method, expose only that method. For Calibur and Safe multi-op Merkle signing, the custom signer must implement `signHash`.
+
+Full example: [`signer/customSigner.ts`](https://github.com/candidelabs/abstractionkit-examples/blob/main/signer/customSigner.ts).
+
+### Safe WebAuthn
+
+Use `fromSafeWebauthn` only for Safe passkey owners. It returns a contract-signature signer, sets `type: "contract"`, and handles Safe's WebAuthn signature encoding.
+
+```ts
+import { SafeAccountV0_3_0, fromSafeWebauthn } from "abstractionkit";
+
+const signer = fromSafeWebauthn({
+  publicKey: { x, y },
+  isInit: userOperation.nonce === 0n,
+  accountClass: SafeAccountV0_3_0,
+  getAssertion: async (challenge) => {
+    return getWebauthnAssertion(challenge);
+  },
+});
+
+userOperation.signature = await safe.signUserOperationWithSigners(
+  userOperation,
+  [signer],
+  chainId,
+);
+```
+
+When creating the UserOperation, pass `expectedSigners: [{ x, y }]` so gas estimation uses the WebAuthn dummy signature size instead of the EOA dummy signature size.
+
+See the [Passkeys guide](/wallet/plugins/passkeys/#sign-with-fromsafewebauthn) and [`passkeys/index.ts`](https://github.com/candidelabs/abstractionkit-examples/blob/main/passkeys/index.ts).
+
+## ExternalSigner shape
+
+```ts
+type ExternalSigner = { address: `0x${string}` } & (
+  | {
+      signHash: (hash: `0x${string}`, context: SignContext) => Promise<`0x${string}`>;
+      signTypedData?: (data: TypedData, context: SignContext) => Promise<`0x${string}`>;
+    }
+  | {
+      signHash?: (hash: `0x${string}`, context: SignContext) => Promise<`0x${string}`>;
+      signTypedData: (data: TypedData, context: SignContext) => Promise<`0x${string}`>;
+    }
+) & {
+  type?: "ecdsa" | "contract";
+};
+```
+
+The optional `type` field defaults to `"ecdsa"`. Safe accounts use `"contract"` for dynamic-length EIP-1271 signatures, including WebAuthn verifier contracts.
+
+Canonical source: [`src/signer/types.ts`](https://github.com/candidelabs/abstractionkit/blob/v0.3.5/src/signer/types.ts).
+
+## Hard rules for agents
+
+- Do not invent signer method names. Use `signUserOperationWithSigners`, `signUserOperationWithSigner`, or `signUserOperationsWithSigners` exactly as shown above.
+- Do not pass bare private-key strings into `signUserOperationWithSigner(s)`. Use `fromPrivateKey(privateKey)` or the legacy sync `signUserOperation(...)` method.
+- Do not use `fromViemWalletClient` for Calibur or Safe multi-op Merkle signing; it does not provide `signHash`.
+- Do not use `fromSafeWebauthn` outside Safe accounts.
+- Do not manually format the result from `signUserOperationWithSigner(s)`. Assign it directly to `userOperation.signature`.
+- Do not call `signMessage` for UserOperations. Use hash signing or typed-data signing through `ExternalSigner`.
+- Read the matching full example before implementing an end-to-end flow.
+
+## End-to-end examples
+
+- [Signer adapter examples](https://github.com/candidelabs/abstractionkit-examples/tree/main/signer)
+- [Simple7702 EntryPoint v0.8 external signer](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/05-external-signer.ts)
+- [Simple7702 EntryPoint v0.9 external signer](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/06-external-signer-v09.ts)
+- [Calibur external signer](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/calibur-account/04-external-signer.ts)
+- [Safe Unified Account external signer](https://github.com/candidelabs/abstractionkit-examples/blob/main/chain-abstraction/add-owner-with-external-signer.ts)
+- [Safe passkeys example](https://github.com/candidelabs/abstractionkit-examples/blob/main/passkeys/index.ts)

--- a/docs/wallet/abstractionkit/14-external-signers.mdx
+++ b/docs/wallet/abstractionkit/14-external-signers.mdx
@@ -1,71 +1,24 @@
 ---
 title: External Signers
-description: Agent-oriented reference for using ExternalSigner adapters with AbstractionKit accounts
+description: Reference for using ExternalSigner adapters with AbstractionKit accounts
 keywords: [external-signer, signer-adapter, viem, ethers, webauthn, mpc, hsm, passkeys, abstractionkit]
 ---
 
 # External Signers
 
-`ExternalSigner` is the AbstractionKit interface for signing UserOperations with wallets, local accounts, passkeys, hardware wallets, HSMs, MPC services, or custom signing backends without passing raw private keys into account methods.
+`ExternalSigner` is the AbstractionKit interface for signing UserOperations without passing raw private keys to the SDK. It plugs viem, ethers, hardware wallets, HSMs, MPC services, passkeys, or any custom signing backend into the same API.
 
-Use this page as the implementation source for signer selection. If you are an AI agent, follow the workflow below before writing code.
+Available since AbstractionKit v0.3.2.
 
-## Agent workflow
-
-### 1. Identify the account type
-
-Pick the signing method from the account class, not from the signer library.
-
-| Account type | Method to call | Signer parameter |
-|---|---|---|
-| Safe accounts (`SafeAccountV0_2_0`, `SafeAccountV0_3_0`, `SafeAccountV1_5_0_M_0_3_0`) | `signUserOperationWithSigners(userOperation, signers, chainId)` | array of `ExternalSigner` |
-| `SafeMultiChainSigAccountV1` single UserOperation | `signUserOperationWithSigners(userOperation, signers, chainId)` | array of `ExternalSigner` |
-| `SafeMultiChainSigAccountV1` multi-op Merkle path | `signUserOperationsWithSigners(userOperationsToSign, signers)` | array of `ExternalSigner` |
-| `Simple7702Account`, `Simple7702AccountV09` | `signUserOperationWithSigner(userOperation, signer, chainId)` | single `ExternalSigner` |
-| `Calibur7702Account` | `signUserOperationWithSigner(userOperation, signer, chainId)` | single `ExternalSigner` |
-
-### 2. Check the signing capability
-
-Every signer must provide `signHash`, `signTypedData`, or both. AbstractionKit negotiates the best supported scheme for the account.
-
-| Account path | Accepted schemes | Agent rule |
-|---|---|---|
-| Safe accounts | `typedData`, `hash` | Prefer signers that can show EIP-712 typed data when available. |
-| `SafeMultiChainSigAccountV1` single UserOperation | `typedData`, `hash` | Same as Safe accounts. |
-| `SafeMultiChainSigAccountV1` multi-op Merkle path | `hash` only | Use a hash-capable signer. Do not use `fromViemWalletClient`. |
-| `Simple7702Account`, `Simple7702AccountV09` | `typedData`, `hash` | JSON-RPC wallets can use typed data on EntryPoint v0.8/v0.9; hash-capable signers also work. |
-| `Calibur7702Account` | `hash` only | Use `fromViem`, `fromEthersWallet`, `fromPrivateKey`, or a custom signer with `signHash`. |
-
-Capability mismatches throw offline before any wallet prompt is shown. If code fails with a signing scheme error, change the adapter or account path instead of retrying the same signer.
-
-### 3. Pick the adapter
-
-| Signing source | Adapter | Provides | Use when |
-|---|---|---|---|
-| Raw private key string | `fromPrivateKey(privateKey)` | `signHash`, `signTypedData` | You need a private key to flow through the async `ExternalSigner` API. |
-| viem local account | `fromViem(localAccount)` | `signHash`, `signTypedData` | You have a viem `LocalAccount`, such as `privateKeyToAccount(pk)`. |
-| viem WalletClient | `fromViemWalletClient(client)` | `signTypedData` only | You use a browser or injected JSON-RPC wallet with Safe or Simple7702 typed-data signing. |
-| ethers Wallet / HDNodeWallet | `fromEthersWallet(wallet)` | `signHash`, `signTypedData` | The project already uses ethers v6 wallet instances. |
-| HSM, MPC, hardware wallet, remote signer | custom `ExternalSigner` | whatever you implement | The signer service exposes hash signing, typed-data signing, or both. |
-| Safe passkey owner | `fromSafeWebauthn(params)` | `signHash`, `type: "contract"` | You are signing a Safe UserOperation with a WebAuthn/passkey owner. |
-
-Do not add viem to a project that already uses ethers just for signing, or ethers to a project that already uses viem. Use the adapter that matches the existing stack.
-
-### 4. Sign and assign the signature
-
-The result of `signUserOperationWithSigner(s)` is already formatted for the account. Assign it directly to `userOperation.signature`.
+## Quick start
 
 ```ts
-userOperation.signature = await account.signUserOperationWithSigner(
-  userOperation,
-  signer,
-  chainId,
-);
-```
+import { SafeAccountV0_3_0 as SafeAccount, fromViem } from "abstractionkit";
+import { privateKeyToAccount } from "viem/accounts";
 
-For Safe accounts, pass one signer per owner required by the threshold:
+const signer = fromViem(privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`));
+const safe = SafeAccount.initializeNewAccount([signer.address]);
 
-```ts
 userOperation.signature = await safe.signUserOperationWithSigners(
   userOperation,
   [signer],
@@ -73,39 +26,52 @@ userOperation.signature = await safe.signUserOperationWithSigners(
 );
 ```
 
-For multi-chain Safe signing, pass the UserOperations and chain IDs together:
+## Picking an adapter
+
+AbstractionKit ships built-in adapters for the common signing sources, plus an open `ExternalSigner` interface for custom backends.
+
+| Signing source | Adapter | Use when |
+|---|---|---|
+| viem `LocalAccount` | `fromViem(localAccount)` | The project uses viem. Works for `privateKeyToAccount`, `toAccount`, and wagmi connector accounts. |
+| viem `WalletClient` | `fromViemWalletClient(client)` | The signer is a browser or injected JSON-RPC wallet (typed-data signing only). |
+| ethers `Wallet` / `HDNodeWallet` | `fromEthersWallet(wallet)` | The project already uses ethers v6. |
+| Raw private key string | `fromPrivateKey(privateKey)` | You want every owner (private key, HSM, hardware) to flow through the same async interface. |
+| Safe passkey owner | `fromSafeWebauthn(params)` | Signing a Safe UserOperation with a WebAuthn credential. |
+| HSM, MPC, hardware wallet, remote signer | custom `ExternalSigner` | Implement the `signHash` and/or `signTypedData` methods your service exposes. |
+
+If your project already uses viem, use `fromViem`; if it uses ethers, use `fromEthersWallet`. You don't need to install both.
+
+## Account compatibility
+
+Each account class exposes its own signing method and accepts a different subset of adapters. The returned signature is already formatted for the account, so assign it directly to `userOperation.signature`.
+
+| Account | Method | Compatible adapters |
+|---|---|---|
+| `SafeAccountV0_2_0`, `SafeAccountV0_3_0`, `SafeAccountV1_5_0_M_0_3_0` | `signUserOperationWithSigners(userOperation, signers, chainId)` | `fromViem`, `fromViemWalletClient`, `fromEthersWallet`, `fromPrivateKey`, `fromSafeWebauthn`, custom |
+| `SafeMultiChainSigAccountV1` (single UserOperation) | `signUserOperationWithSigners(userOperation, signers, chainId)` | `fromViem`, `fromViemWalletClient`, `fromEthersWallet`, `fromPrivateKey`, `fromSafeWebauthn`, custom |
+| `SafeMultiChainSigAccountV1` (multi-op Merkle path) | `signUserOperationsWithSigners(userOperationsToSign, signers)` | `fromViem`, `fromEthersWallet`, `fromPrivateKey`, `fromSafeWebauthn`, custom (`signHash` required) |
+| `Simple7702Account`, `Simple7702AccountV09` | `signUserOperationWithSigner(userOperation, signer, chainId)` | `fromViem`, `fromViemWalletClient`, `fromEthersWallet`, `fromPrivateKey`, custom |
+| `Calibur7702Account` | `signUserOperationWithSigner(userOperation, signer, chainId)` | `fromViem`, `fromEthersWallet`, `fromPrivateKey`, custom (`signHash` required) |
+
+For Safe accounts, pass one signer per owner required by the threshold. For multi-chain Safe signing, pass the UserOperations and chain IDs together:
 
 ```ts
 const signatures = await safe.signUserOperationsWithSigners(
   [
-    { userOperation: op1, chainId: 11155111n },
-    { userOperation: op2, chainId: 84532n },
+    { chainId: 11155111n, userOperation: op1 },
+    { chainId: 84532n, userOperation: op2 },
   ],
   [signer],
 );
 ```
 
+Under the hood, every signer implements `signHash`, `signTypedData`, or both, and each account picks the scheme it prefers (typed data when supported, so wallets can display structured EIP-712 fields). Capability mismatches throw offline with an actionable error before any wallet prompt is shown. `fromViemWalletClient` is typed-data only, which is why it cannot drive the Calibur or multi-op Merkle paths (both require raw-hash signing). `fromSafeWebauthn` is Safe-specific because it produces an EIP-1271 contract signature using Safe's WebAuthn verifier.
+
 ## Adapter recipes
-
-### Raw private key
-
-Use this when the codebase wants all signers to share the async `ExternalSigner` path. For a simple single-owner private-key script, the legacy sync `signUserOperation(userOperation, [privateKey], chainId)` API is still shorter.
-
-```ts
-import { fromPrivateKey } from "abstractionkit";
-
-const signer = fromPrivateKey(process.env.PRIVATE_KEY as `0x${string}`);
-
-userOperation.signature = await safe.signUserOperationWithSigners(
-  userOperation,
-  [signer],
-  chainId,
-);
-```
 
 ### viem local account
 
-Use `fromViem` with viem `LocalAccount` objects. This is the preferred viem adapter for scripts, backends, and local private-key accounts because it supports both hash and typed-data signing.
+`fromViem` is the preferred viem adapter for scripts, backends, and any local private-key account. It supports both hash and typed-data signing.
 
 ```ts
 import { SafeAccountV0_3_0 as SafeAccount, fromViem } from "abstractionkit";
@@ -126,7 +92,7 @@ Full example: [`signer/fromViem.ts`](https://github.com/candidelabs/abstractionk
 
 ### viem WalletClient
 
-Use `fromViemWalletClient` for browser wallets and injected JSON-RPC wallets. It only exposes `signTypedData`, so do not use it for Calibur or the Safe multi-op Merkle path.
+Use `fromViemWalletClient` for browser wallets and injected JSON-RPC wallets. It only exposes `signTypedData`, so it does not work with Calibur or the Safe multi-op Merkle path.
 
 ```ts
 import { SafeAccountV0_3_0 as SafeAccount, fromViemWalletClient } from "abstractionkit";
@@ -151,7 +117,7 @@ Full example: [`signer/fromViemWalletClient.ts`](https://github.com/candidelabs/
 
 ### ethers Wallet
 
-Use `fromEthersWallet` when the project already uses ethers v6.
+`fromEthersWallet` accepts any ethers v6 `Wallet` or `HDNodeWallet`.
 
 ```ts
 import { SafeAccountV0_3_0 as SafeAccount, fromEthersWallet } from "abstractionkit";
@@ -170,9 +136,31 @@ userOperation.signature = await safe.signUserOperationWithSigners(
 
 Full example: [`signer/fromEthersWallet.ts`](https://github.com/candidelabs/abstractionkit-examples/blob/main/signer/fromEthersWallet.ts).
 
+### Raw private key
+
+For a single-owner private-key setup, the sync `signUserOperation` method is the shortest path and needs no adapter:
+
+```ts
+userOperation.signature = smartAccount.signUserOperation(userOperation, [privateKey], chainId);
+```
+
+Use `fromPrivateKey` when you want every owner (private key, HSM, hardware) to share the same async `ExternalSigner` interface in a multi-owner setup:
+
+```ts
+import { fromPrivateKey } from "abstractionkit";
+
+const signer = fromPrivateKey(process.env.PRIVATE_KEY as `0x${string}`);
+
+userOperation.signature = await safe.signUserOperationWithSigners(
+  userOperation,
+  [signer],
+  chainId,
+);
+```
+
 ### Custom signer
 
-Use a custom `ExternalSigner` for HSMs, MPC providers, hardware wallets, secure enclaves, or remote signing APIs. Implement the capability your account path needs.
+Use a custom `ExternalSigner` for HSMs, MPC providers, hardware wallets, secure enclaves, or remote signing APIs. Implement only the methods your service supports.
 
 ```ts
 import type { ExternalSigner } from "abstractionkit";
@@ -180,23 +168,19 @@ import type { ExternalSigner } from "abstractionkit";
 const signer: ExternalSigner = {
   address: deviceAddress as `0x${string}`,
   signHash: async (hash) => {
-    const signature = await hsmClient.signHash(hash);
-    return signature as `0x${string}`;
+    return (await hsmClient.signHash(hash)) as `0x${string}`;
   },
   signTypedData: async (typedData) => {
-    const signature = await mpcClient.signTypedData(typedData);
-    return signature as `0x${string}`;
+    return (await mpcClient.signTypedData(typedData)) as `0x${string}`;
   },
 };
 ```
 
-If the service only supports one method, expose only that method. For Calibur and Safe multi-op Merkle signing, the custom signer must implement `signHash`.
-
 Full example: [`signer/customSigner.ts`](https://github.com/candidelabs/abstractionkit-examples/blob/main/signer/customSigner.ts).
 
-### Safe WebAuthn
+### Safe WebAuthn (passkeys)
 
-Use `fromSafeWebauthn` only for Safe passkey owners. It returns a contract-signature signer, sets `type: "contract"`, and handles Safe's WebAuthn signature encoding.
+`fromSafeWebauthn` is Safe-specific. It returns a contract-signature signer, sets `type: "contract"`, and handles Safe's WebAuthn signature encoding.
 
 ```ts
 import { SafeAccountV0_3_0, fromSafeWebauthn } from "abstractionkit";
@@ -219,7 +203,7 @@ userOperation.signature = await safe.signUserOperationWithSigners(
 
 When creating the UserOperation, pass `expectedSigners: [{ x, y }]` so gas estimation uses the WebAuthn dummy signature size instead of the EOA dummy signature size.
 
-See the [Passkeys guide](/wallet/plugins/passkeys/#sign-with-fromsafewebauthn) and [`passkeys/index.ts`](https://github.com/candidelabs/abstractionkit-examples/blob/main/passkeys/index.ts).
+See the [Passkeys guide](/wallet/plugins/passkeys/#sign-with-fromsafewebauthn) and the [`passkeys/index.ts`](https://github.com/candidelabs/abstractionkit-examples/blob/main/passkeys/index.ts) example.
 
 ## ExternalSigner shape
 
@@ -238,19 +222,9 @@ type ExternalSigner = { address: `0x${string}` } & (
 };
 ```
 
-The optional `type` field defaults to `"ecdsa"`. Safe accounts use `"contract"` for dynamic-length EIP-1271 signatures, including WebAuthn verifier contracts.
+The discriminated union enforces at compile time that every signer implements at least one of `signHash` or `signTypedData`. The optional `type` field defaults to `"ecdsa"`. Safe accounts use `"contract"` for dynamic-length EIP-1271 signatures, including WebAuthn verifier contracts.
 
-Canonical source: [`src/signer/types.ts`](https://github.com/candidelabs/abstractionkit/blob/v0.3.5/src/signer/types.ts).
-
-## Hard rules for agents
-
-- Do not invent signer method names. Use `signUserOperationWithSigners`, `signUserOperationWithSigner`, or `signUserOperationsWithSigners` exactly as shown above.
-- Do not pass bare private-key strings into `signUserOperationWithSigner(s)`. Use `fromPrivateKey(privateKey)` or the legacy sync `signUserOperation(...)` method.
-- Do not use `fromViemWalletClient` for Calibur or Safe multi-op Merkle signing; it does not provide `signHash`.
-- Do not use `fromSafeWebauthn` outside Safe accounts.
-- Do not manually format the result from `signUserOperationWithSigner(s)`. Assign it directly to `userOperation.signature`.
-- Do not call `signMessage` for UserOperations. Use hash signing or typed-data signing through `ExternalSigner`.
-- Read the matching full example before implementing an end-to-end flow.
+Canonical source: [`src/signer/types.ts`](https://github.com/candidelabs/abstractionkit/blob/v0.3.7/src/signer/types.ts).
 
 ## End-to-end examples
 

--- a/docs/wallet/abstractionkit/7-safe-account-v2.mdx
+++ b/docs/wallet/abstractionkit/7-safe-account-v2.mdx
@@ -394,7 +394,7 @@ console.log(signature);
 
 ### signUserOperationWithSigners
 
-Signs a UserOperation using one or more [`ExternalSigner`s](/wallet/guides/authentication#external-signers) instead of raw private keys. Integrates viem, ethers, hardware wallets, HSMs, MPC services, and WebAuthn through the same API.
+Signs a UserOperation using one or more [`ExternalSigner`s](/wallet/abstractionkit/external-signers) instead of raw private keys. Integrates viem, ethers, hardware wallets, HSMs, MPC services, and WebAuthn through the same API.
 
 ```ts title="example.ts"
 import { fromEthersWallet } from "abstractionkit";
@@ -409,7 +409,7 @@ userOperation.signature = await smartAccount.signUserOperationWithSigners(
 );
 ```
 
-See [External Signers](/wallet/guides/authentication#external-signers) for the full list of adapters and custom-signer integrations.
+See [External Signers](/wallet/abstractionkit/external-signers) for the full list of adapters and custom-signer integrations.
 
 #### Source code
 [signUserOperationWithSigners](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccount.ts)

--- a/docs/wallet/abstractionkit/8-safe-account-v3.mdx
+++ b/docs/wallet/abstractionkit/8-safe-account-v3.mdx
@@ -367,7 +367,7 @@ console.log(signature);
 
 ### signUserOperationWithSigners
 
-Signs a UserOperation using one or more [`ExternalSigner`s](/wallet/guides/authentication#external-signers) instead of raw private keys. Integrates viem, ethers, hardware wallets, HSMs, MPC services, and WebAuthn through the same API.
+Signs a UserOperation using one or more [`ExternalSigner`s](/wallet/abstractionkit/external-signers) instead of raw private keys. Integrates viem, ethers, hardware wallets, HSMs, MPC services, and WebAuthn through the same API.
 
 ```ts title="example.ts"
 import { fromViem } from "abstractionkit";
@@ -382,7 +382,7 @@ userOperation.signature = await smartAccount.signUserOperationWithSigners(
 );
 ```
 
-See [External Signers](/wallet/guides/authentication#external-signers) for the full list of adapters and custom-signer integrations.
+See [External Signers](/wallet/abstractionkit/external-signers) for the full list of adapters and custom-signer integrations.
 
 #### Source code
 [signUserOperationWithSigners](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccount.ts)

--- a/docs/wallet/guides/5-authentication.mdx
+++ b/docs/wallet/guides/5-authentication.mdx
@@ -232,6 +232,8 @@ userOperation.signature = smartAccount.signUserOperation(
 
 Available since AbstractionKit v0.3.2. `ExternalSigner` is a capability-oriented interface that lets you plug any signing source into AbstractionKit without passing raw private keys to the SDK. It covers viem local accounts, viem WalletClients, ethers Wallets, hardware wallets, HSMs, MPC services, and WebAuthn signers through a single API.
 
+Use the [External Signers SDK reference](/wallet/abstractionkit/external-signers) for the agent-oriented decision workflow, compatibility tables, adapter recipes, and full example links.
+
 Every account class exposes the same method family:
 
 ```ts
@@ -247,70 +249,3 @@ const signatures = await account.signUserOperationsWithSigners(
   [signer],
 )
 ```
-
-### Pick an adapter
-
-AbstractionKit ships built-in adapters and supports custom `ExternalSigner` implementations. Each adapter wraps a concrete signer type into an `ExternalSigner` in one line.
-
-**Built-in adapters**
-
-| Adapter | For | Example |
-|---|---|---|
-| `fromViem(localAccount)` | any viem `LocalAccount` (`privateKeyToAccount`, `toAccount`, wagmi connector accounts) | [fromViem.ts](https://github.com/candidelabs/abstractionkit-examples/blob/main/signer/fromViem.ts) |
-| `fromEthersWallet(wallet)` | any ethers `Wallet` or `HDNodeWallet` (ethers >= 6) | [fromEthersWallet.ts](https://github.com/candidelabs/abstractionkit-examples/blob/main/signer/fromEthersWallet.ts) |
-| `fromViemWalletClient(client)` | viem `WalletClient` (browser / injected wallet, typed-data only) | [fromViemWalletClient.ts](https://github.com/candidelabs/abstractionkit-examples/blob/main/signer/fromViemWalletClient.ts) |
-| `fromSafeWebauthn(params)` | Safe passkey owners; returns a contract-signature signer for `signUserOperationWithSigners` | [Passkeys guide](/wallet/plugins/passkeys/#sign-with-fromsafewebauthn) |
-
-Each example in the repo is self-contained. If you use viem, read `fromViem.ts`; if you use ethers, read `fromEthersWallet.ts`. You do not need to install both libraries to use AbstractionKit.
-
-**Custom / extensible**
-
-For HSMs, MPC services, hardware wallets, `Uint8Array`-held keys, or WebAuthn, implement the `ExternalSigner` interface directly: see [customSigner.ts](https://github.com/candidelabs/abstractionkit-examples/blob/main/signer/customSigner.ts) for a reference implementation.
-
-:::tip Raw private keys
-For a single-owner private-key setup, the legacy sync API is the shortest path and needs no adapter:
-
-```ts
-userOperation.signature = smartAccount.signUserOperation(userOperation, [privateKey], chainId)
-```
-
-`fromPrivateKey(pk)` also exists when you want every owner (pk, HSM, hardware wallet) to flow through the same async interface in a multi-owner setup.
-:::
-
-### Shape
-
-```ts
-type ExternalSigner = { address: `0x${string}` } & (
-  | { signHash:       (hash: `0x${string}`) => Promise<`0x${string}`>
-      signTypedData?: (data: TypedData)     => Promise<`0x${string}`> }
-  | { signHash?:      (hash: `0x${string}`) => Promise<`0x${string}`>
-      signTypedData:  (data: TypedData)     => Promise<`0x${string}`> }
-) & {
-  type?: "ecdsa" | "contract"
-}
-```
-
-The discriminated union enforces at compile time that every signer implements at least one of `signHash` or `signTypedData`. The optional `type` field defaults to `"ecdsa"`; Safe accounts use `"contract"` for dynamic-length EIP-1271 signatures such as WebAuthn verifier contracts. Canonical definition in [`src/signer/types.ts`](https://github.com/candidelabs/abstractionkit/blob/v0.3.5/src/signer/types.ts), re-exported from the package root as `ExternalSigner`.
-
-### Capability negotiation
-
-Each account class declares which signing schemes it accepts:
-
-| Account | Accepted schemes | Notes |
-|---|---|---|
-| Safe (V0.2.0, V0.3.0, V1.5.0) | `typedData`, `hash` | Prefers `typedData` for structured EIP-712 display in wallet UIs |
-| `SafeMultiChainSigAccountV1` (single-op) | `typedData`, `hash` | Same preference as Safe |
-| `SafeMultiChainSigAccountV1` (multi-op Merkle path) | `hash` only | The Merkle root has no typed-data display |
-| `Simple7702Account`, `Simple7702AccountV09` | `typedData`, `hash` | Since v0.3.5, prefers EntryPoint v0.8/v0.9 EIP-712 typed data for JSON-RPC wallets; raw-hash signing remains supported |
-| `Calibur7702Account` | `hash` only | Raw 32-byte hash, no EIP-191 prefix |
-
-When a signer exposes both capabilities the account picks the preferred scheme. Capability mismatches throw **offline** with an actionable error: a `fromViemWalletClient` signer (typed-data only) passed to Calibur or to the multi-op Merkle path fails before any wallet prompt is triggered.
-
-### Account-specific flows
-
-Full end-to-end scripts in the examples repo:
-
-- [Simple7702 (EntryPoint v0.8)](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/05-external-signer.ts)
-- [Simple7702 (EntryPoint v0.9, two-phase paymaster)](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/06-external-signer-v09.ts)
-- [Calibur](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/calibur-account/04-external-signer.ts)
-- [Safe Unified Account: multi-chain add-owner with one signature](https://github.com/candidelabs/abstractionkit-examples/blob/main/chain-abstraction/add-owner-with-external-signer.ts)

--- a/sidebars.js
+++ b/sidebars.js
@@ -578,6 +578,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "wallet/abstractionkit/external-signers",
+          label: "External Signers"
+        },
+        {
+          type: "doc",
           id: "wallet/abstractionkit/bundler",
           label: "Bundler"
         },


### PR DESCRIPTION
## Summary
- add a dedicated External Signers SDK reference page for agent-oriented adapter selection
- move detailed adapter guidance out of the Authentication guide and link to the canonical reference
- add the new page to the SDK Reference sidebar

## Test
- yarn build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive External Signers reference detailing signer capabilities, adapter selection, recipes for common signing methods, and guidance for assigning signatures to UserOperations.
  * Updated authentication and account guides to link to the new External Signers reference and adjusted related examples.
  * Updated Safe account docs to reference the latest source locations and clarified signer-related usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->