### PR TITLE
docs: update AbstractionKit SDK references

### DIFF
--- a/blog/2024-09-30-abstractionkit-v0.2.0-release/index.mdx
+++ b/blog/2024-09-30-abstractionkit-v0.2.0-release/index.mdx
@@ -42,7 +42,7 @@ We highlight here the main features and the changelog for developers integrating
    ```js
    import { CandidePaymaster } from "abstractionkit";
 
-   const paymasterRpc = "https://api.candide.dev/public/v3/sepolia";
+   const paymasterRpc = "https://api.candide.dev/public/v3/11155111";
    const paymaster: CandidePaymaster = new CandidePaymaster(paymasterRPC);
 
    // Construct user operation using createUserOperation()

--- a/docs/wallet/abstractionkit/0-introduction.mdx
+++ b/docs/wallet/abstractionkit/0-introduction.mdx
@@ -65,10 +65,13 @@ yarn add abstractionkit
 </TabItem>
 </Tabs>
 
+## Current SDK version
+
+The docs track AbstractionKit `v0.3.8`.
+
 ## Resources
 
 - **Source code**: [github.com/candidelabs/abstractionkit](https://github.com/candidelabs/abstractionkit)
 - **Full changelog**: [github.com/candidelabs/abstractionkit/blob/main/CHANGELOG.md](https://github.com/candidelabs/abstractionkit/blob/main/CHANGELOG.md) — exhaustive list of every release, including breaking changes and migration snippets. Release highlights also appear in the [blog](/blog).
 - **Examples**: [github.com/candidelabs/abstractionkit-examples](https://github.com/candidelabs/abstractionkit-examples)
 - **npm**: [npmjs.com/package/abstractionkit](https://www.npmjs.com/package/abstractionkit)
-

--- a/docs/wallet/abstractionkit/1.bundler.mdx
+++ b/docs/wallet/abstractionkit/1.bundler.mdx
@@ -25,7 +25,7 @@ import { userOperationReturnParamsV06, userOperationParamV07, userOperationParam
 
 The `Bundler` class provides access to ERC-4337 Bundler JSON-RPC API methods for estimating user operation gas and sending user operations.
 
-The `Bundler` class creates a Bundler instance with a [Bundler RPC URL](../../bundler/rpc-endpoints).
+The `Bundler` class creates a Bundler instance with a [Bundler RPC URL](../../bundler/rpc-endpoints) or an EIP-1193-shaped `Transport`.
 
 ## Usage
 
@@ -45,6 +45,16 @@ const bundlerRPC = "https://api.candide.dev/public/v3/sepolia";
 const bundler: Bundler = new Bundler(bundlerRPC);
 ```
 
+You can also pass a custom transport when you need request cancellation, custom headers, retries, telemetry, or an injected provider:
+
+```ts
+import { Bundler, HttpTransport } from "abstractionkit";
+
+const bundler = new Bundler(
+  new HttpTransport("https://api.candide.dev/public/v3/sepolia"),
+);
+```
+
 Then consume Bundler methods:
 
 ```ts
@@ -53,7 +63,9 @@ const entrypointAddresses = await bundler.supportedEntryPoints();
 
 ### Parameters
 
-#### bundlerURL `string`
+#### bundlerRPC `string | Transport`
+
+`Bundler`, `CandidePaymaster`, and `Erc7677Paymaster` accept either an RPC URL string or a `Transport`. Each service also exposes `transport`, which replaces the old `rpcUrl` field.
 
 ## Methods
 

--- a/docs/wallet/abstractionkit/1.bundler.mdx
+++ b/docs/wallet/abstractionkit/1.bundler.mdx
@@ -40,7 +40,7 @@ import { Bundler } from "abstractionkit";
 Initialize a Bundler with your desired bundler RPC URL:
 
 ```ts
-const bundlerRPC = "https://api.candide.dev/public/v3/sepolia";
+const bundlerRPC = "https://api.candide.dev/public/v3/11155111";
 
 const bundler: Bundler = new Bundler(bundlerRPC);
 ```
@@ -51,7 +51,7 @@ You can also pass a custom transport when you need request cancellation, custom 
 import { Bundler, HttpTransport } from "abstractionkit";
 
 const bundler = new Bundler(
-  new HttpTransport("https://api.candide.dev/public/v3/sepolia"),
+  new HttpTransport("https://api.candide.dev/public/v3/11155111"),
 );
 ```
 
@@ -81,7 +81,7 @@ Returns the chain ID of the network the bundler is operating on.
 ```ts title="example.ts"
 import { Bundler } from "abstractionkit";
 
-const bundlerRPC = "https://api.candide.dev/public/v3/sepolia";
+const bundlerRPC = "https://api.candide.dev/public/v3/11155111";
 const bundler: Bundler = new Bundler(bundlerRPC);
 // highlight-start
 const getChainId = await bundler.chainId();
@@ -119,7 +119,7 @@ Returns the list of the entryPoint addresses supported by the bundler
 ```ts title="example.ts"
 import { Bundler } from "abstractionkit";
 
-const bundlerRPC = "https://api.candide.dev/public/v3/sepolia";
+const bundlerRPC = "https://api.candide.dev/public/v3/11155111";
 const bundler: Bundler = new Bundler(bundlerRPC);
 //highlight-start
 const entrypointAddresses = await bundler.supportedEntryPoints();
@@ -161,7 +161,7 @@ See a full example in [getting-started guide](../../guides/getting-started)
 ```ts title="example.ts"
 import { Bundler, UserOperationV7 } from "abstractionkit";
 
-const bundlerRPC = "https://api.candide.dev/public/v3/sepolia";
+const bundlerRPC = "https://api.candide.dev/public/v3/11155111";
 const bundler: Bundler = new Bundler(bundlerRPC);
 
 // Use createUserOperation() to help you construct the userOp below
@@ -218,7 +218,7 @@ See a full example in [getting-started guide](../../guides/getting-started)
 ```ts title="example.ts"
 import { Bundler } from "abstractionkit";
 
-const bundlerRPC = "https://api.candide.dev/public/v3/sepolia";
+const bundlerRPC = "https://api.candide.dev/public/v3/11155111";
 const bundler: Bundler = new Bundler(bundlerRPC);
 const entrypointAddress = "0x0000000071727De22E5E9d8BAf0edAc6f37da032";
 // Use createUserOperation() to help you construct the userOp below
@@ -270,7 +270,7 @@ Returns a UserOperation by its hash returned from sendUserOperation
 ```ts title="example.ts"
 import { Bundler } from "abstractionkit";
 
-const bundlerRPC = "https://api.candide.dev/public/v3/sepolia";
+const bundlerRPC = "https://api.candide.dev/public/v3/11155111";
 const bundler: Bundler = new Bundler(bundlerRPC);
 const userOperationHash = "0xb348b32bc9b9e90620839c3926db401558806b03b2a46dc6de21d3a4ed8412fb";
 
@@ -336,7 +336,7 @@ Returns the receipt of a UserOperation by its hash returned from `sendUserOperat
 ```ts title="example.ts"
 import { Bundler } from "abstractionkit";
 
-const bundlerRPC = "https://api.candide.dev/public/v3/sepolia";
+const bundlerRPC = "https://api.candide.dev/public/v3/11155111";
 const bundler: Bundler = new Bundler(bundlerRPC);
 const userOperationHash = "0xb348b32bc9b9e90620839c3926db401558806b03b2a46dc6de21d3a4ed8412fb";
 

--- a/docs/wallet/abstractionkit/10-simple-7702-account-v09.mdx
+++ b/docs/wallet/abstractionkit/10-simple-7702-account-v09.mdx
@@ -206,12 +206,14 @@ userOperation.signature = await smartAccount.signUserOperationWithSigner(
 
 See [External Signers](/wallet/abstractionkit/external-signers) for the full list of adapters and custom-signer integrations. EntryPoint v0.9 also supports parallel paymaster signing via the two-phase `signingPhase` context — see the [v0.9 external-signer example](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/06-external-signer-v09.ts).
 
-### getUserOperationEip712TypedData
+### getUserOperationEip712Data
 
-Builds the EIP-712 typed data payload for a UserOperation under the EntryPoint v0.9 domain. Use this lower-level method when you need to inspect the wallet prompt payload or drive a custom `signTypedData` primitive directly.
+Builds the EIP-712 typed data payload for a UserOperation under the EntryPoint v0.9 domain. Use this static helper when you need to inspect the wallet prompt payload or drive a custom `signTypedData` primitive directly.
 
 ```ts title="example.ts"
-const typedData = smartAccount.getUserOperationEip712TypedData(
+import { Simple7702AccountV09 } from "abstractionkit";
+
+const typedData = Simple7702AccountV09.getUserOperationEip712Data(
   userOperation,
   11155111n,
 );
@@ -219,6 +221,8 @@ const typedData = smartAccount.getUserOperationEip712TypedData(
 const signature = await walletClient.signTypedData(typedData);
 userOperation.signature = signature;
 ```
+
+`getUserOperationEip712TypedData` was renamed in `v0.3.8` and moved from an instance method to a static helper. Use `getUserOperationEip712Hash(userOperation, chainId, overrides?)` when you only need the digest.
 
 ### sendUserOperation
 

--- a/docs/wallet/abstractionkit/11-simple-7702-account-v08.mdx
+++ b/docs/wallet/abstractionkit/11-simple-7702-account-v08.mdx
@@ -203,12 +203,14 @@ userOperation.signature = await smartAccount.signUserOperationWithSigner(
 
 See [External Signers](/wallet/abstractionkit/external-signers) for the full list of adapters and custom-signer integrations.
 
-### getUserOperationEip712TypedData
+### getUserOperationEip712Data
 
-Builds the EIP-712 typed data payload for a UserOperation under the EntryPoint v0.8 domain. Use this lower-level method when you need to inspect the wallet prompt payload or drive a custom `signTypedData` primitive directly.
+Builds the EIP-712 typed data payload for a UserOperation under the EntryPoint v0.8 domain. Use this static helper when you need to inspect the wallet prompt payload or drive a custom `signTypedData` primitive directly.
 
 ```ts title="example.ts"
-const typedData = smartAccount.getUserOperationEip712TypedData(
+import { Simple7702Account } from "abstractionkit";
+
+const typedData = Simple7702Account.getUserOperationEip712Data(
   userOperation,
   11155111n,
 );
@@ -216,6 +218,8 @@ const typedData = smartAccount.getUserOperationEip712TypedData(
 const signature = await walletClient.signTypedData(typedData);
 userOperation.signature = signature;
 ```
+
+`getUserOperationEip712TypedData` was renamed in `v0.3.8` and moved from an instance method to a static helper. Use `getUserOperationEip712Hash(userOperation, chainId, overrides?)` when you only need the digest.
 
 ### sendUserOperation
 

--- a/docs/wallet/abstractionkit/11-simple-7702-account-v08.mdx
+++ b/docs/wallet/abstractionkit/11-simple-7702-account-v08.mdx
@@ -121,7 +121,7 @@ const transactions = [
 const userOperation = await smartAccount.createUserOperation(
   transactions,
   "https://ethereum-sepolia-rpc.publicnode.com", // provider RPC
-  "https://api.candide.dev/public/v3/sepolia", // bundler RPC
+  "https://api.candide.dev/public/v3/11155111", // bundler RPC
   {
     eip7702Auth:{
         chainId, // chainId at which the account will be authorized
@@ -231,7 +231,7 @@ Sends a signed UserOperation to the bundler for execution on-chain.
 ```ts title="example.ts"
 const response = await smartAccount.sendUserOperation(
   userOperation,
-  "https://api.candide.dev/public/v3/sepolia" // bundler URL
+  "https://api.candide.dev/public/v3/11155111" // bundler URL
 );
 
 console.log("UserOperation hash:", response.userOperationHash);
@@ -412,7 +412,7 @@ Estimates gas limits for a UserOperation using the bundler.
 const [preVerificationGas, verificationGasLimit, callGasLimit] =
   await smartAccount.estimateUserOperationGas(
     userOperation,
-    "https://api.candide.dev/public/v3/sepolia",
+    "https://api.candide.dev/public/v3/11155111",
     {
       // Optional overrides
       stateOverrideSet: {...},

--- a/docs/wallet/abstractionkit/12-calibur-account.mdx
+++ b/docs/wallet/abstractionkit/12-calibur-account.mdx
@@ -187,7 +187,7 @@ const transactions = [
 const userOperation = await smartAccount.createUserOperation(
   transactions,
   "https://ethereum-sepolia-rpc.publicnode.com", // provider RPC
-  "https://api.candide.dev/public/v3/sepolia", // bundler RPC
+  "https://api.candide.dev/public/v3/11155111", // bundler RPC
   {
     eip7702Auth: {
       chainId: 11155111n, // required for the first UserOperation
@@ -357,7 +357,7 @@ Sends a signed UserOperation to the bundler for execution on-chain.
 ```ts title="example.ts"
 const response = await smartAccount.sendUserOperation(
   userOperation,
-  "https://api.candide.dev/public/v3/sepolia" // bundler URL
+  "https://api.candide.dev/public/v3/11155111" // bundler URL
 );
 
 console.log("UserOperation hash:", response.userOperationHash);

--- a/docs/wallet/abstractionkit/12-calibur-account.mdx
+++ b/docs/wallet/abstractionkit/12-calibur-account.mdx
@@ -212,7 +212,7 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L246)
+[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L327)
 
 ### signUserOperation
 
@@ -251,13 +251,13 @@ userOperation.signature = smartAccount.signUserOperation(
 </Tabs>
 
 #### Source code
-[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L583)
+[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L671)
 
 ### signUserOperationWithSigner
 
-Signs a UserOperation using an [`ExternalSigner`](/wallet/abstractionkit/external-signers) instead of a raw private key. Integrates viem, ethers, hardware wallets, HSMs, MPC, and WebAuthn through the same API. By default signs with the root key; pass `{ keyHash }` to sign with a registered secondary key.
+Signs a UserOperation using an [`ExternalSigner`](/wallet/abstractionkit/external-signers) instead of a raw private key. Integrates viem, ethers, browser wallets, hardware wallets, HSMs, MPC, and WebAuthn through the same API. By default signs with the root key; pass `{ keyHash }` to sign with a registered secondary key.
 
-Calibur requires a signer that implements `signHash` (raw 32-byte hash, no EIP-191 prefix). Signers that only expose `signTypedData` (e.g. a viem `WalletClient` via `fromViemWalletClient`) fail offline with an actionable error.
+Since `v0.3.8`, Calibur accepts signers that implement either `signHash` or `signTypedData`. `signTypedData` signatures are wrapped into Calibur's `(keyHash, sig, hookData)` layout automatically.
 
 <Tabs>
 <TabItem value="example.ts" label="example.ts">
@@ -299,7 +299,7 @@ See [External Signers](/wallet/abstractionkit/external-signers) for the full lis
 </Tabs>
 
 #### Source code
-[signUserOperationWithSigner](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L624)
+[signUserOperationWithSigner](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L716)
 
 ### formatWebAuthnSignature
 
@@ -345,7 +345,7 @@ userOperation.signature = smartAccount.formatWebAuthnSignature(
 </Tabs>
 
 #### Source code
-[formatWebAuthnSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L659)
+[formatWebAuthnSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L757)
 
 ### sendUserOperation
 
@@ -386,7 +386,7 @@ console.log("Transaction receipt:", receipt);
 </Tabs>
 
 #### Source code
-[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L694)
+[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L792)
 
 ## Key Management Methods
 
@@ -422,7 +422,7 @@ console.log(key);
 </Tabs>
 
 #### Source code
-[createSecp256k1Key](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L714)
+[createSecp256k1Key](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L812)
 
 ### createWebAuthnP256Key
 
@@ -458,7 +458,7 @@ console.log("Key hash:", keyHash);
 </Tabs>
 
 #### Source code
-[createWebAuthnP256Key](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L728)
+[createWebAuthnP256Key](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L826)
 
 ### createP256Key
 
@@ -493,7 +493,7 @@ console.log("Key hash:", keyHash);
 </Tabs>
 
 #### Source code
-[createP256Key](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L742)
+[createP256Key](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L840)
 
 ### getKeyHash
 
@@ -527,7 +527,7 @@ console.log("Key hash:", keyHash);
 </Tabs>
 
 #### Source code
-[getKeyHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L757)
+[getKeyHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L855)
 
 ### createRegisterKeyMetaTransactions
 
@@ -573,7 +573,7 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createRegisterKeyMetaTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L806)
+[createRegisterKeyMetaTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L904)
 
 ### createRevokeKeyMetaTransaction
 
@@ -609,7 +609,7 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createRevokeKeyMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L847)
+[createRevokeKeyMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L945)
 
 ### createUpdateKeySettingsMetaTransaction
 
@@ -653,7 +653,7 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createUpdateKeySettingsMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L1036)
+[createUpdateKeySettingsMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L1134)
 
 ### packKeySettings
 
@@ -689,7 +689,7 @@ console.log("Packed settings:", packed);
 </Tabs>
 
 #### Source code
-[packKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L771)
+[packKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L869)
 
 ### unpackKeySettings
 
@@ -724,7 +724,7 @@ console.log("Hook:", settings.hook);
 </Tabs>
 
 #### Source code
-[unpackKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L784)
+[unpackKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L882)
 
 ## Read Methods
 
@@ -758,7 +758,7 @@ console.log("Key registered:", isRegistered);
 </Tabs>
 
 #### Source code
-[isKeyRegistered](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L1104)
+[isKeyRegistered](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L1202)
 
 ### getKeySettings
 
@@ -794,7 +794,7 @@ console.log("Hook:", settings.hook);
 </Tabs>
 
 #### Source code
-[getKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L1131)
+[getKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L1229)
 
 ### getKey
 
@@ -829,7 +829,7 @@ console.log("Public key:", key.publicKey);
 </Tabs>
 
 #### Source code
-[getKey](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L1161)
+[getKey](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L1259)
 
 ### getKeys
 
@@ -865,7 +865,7 @@ for (const key of keys) {
 </Tabs>
 
 #### Source code
-[getKeys](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L1195)
+[getKeys](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L1293)
 
 ### isDelegatedToThisAccount
 
@@ -899,7 +899,7 @@ if (isDelegated) {
 </Tabs>
 
 #### Source code
-[isDelegatedToThisAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L1080)
+[isDelegatedToThisAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L1178)
 
 ### getNonce
 
@@ -935,7 +935,7 @@ const parallelNonce = await smartAccount.getNonce(
 </Tabs>
 
 #### Source code
-[getNonce](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L1093)
+[getNonce](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L1191)
 
 ## Utility Methods
 
@@ -973,7 +973,7 @@ const callDataNoRevert = Calibur7702Account.createAccountCallData(transactions, 
 </Tabs>
 
 #### Source code
-[createAccountCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L216)
+[createAccountCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L297)
 
 ### wrapSignature
 
@@ -1017,7 +1017,7 @@ const wrappedWithHook = Calibur7702Account.wrapSignature(
 </Tabs>
 
 #### Source code
-[wrapSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L164)
+[wrapSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L166)
 
 ### createDummyWebAuthnSignature
 
@@ -1055,7 +1055,7 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createDummyWebAuthnSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L124)
+[createDummyWebAuthnSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L126)
 
 ### getUserOperationHash
 
@@ -1087,7 +1087,7 @@ console.log("UserOperation hash:", userOpHash);
 </Tabs>
 
 #### Source code
-[getUserOperationHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L202)
+[getUserOperationHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L231)
 
 ### prependTokenPaymasterApproveToCallData
 
@@ -1120,7 +1120,7 @@ userOperation.callData = callDataWithApproval;
 </Tabs>
 
 #### Source code
-[prependTokenPaymasterApproveToCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L1282)
+[prependTokenPaymasterApproveToCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L1380)
 
 ### createInvalidateNonceMetaTransaction
 
@@ -1155,4 +1155,4 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createInvalidateNonceMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Calibur/Calibur7702Account.ts#L1062)
+[createInvalidateNonceMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L1160)

--- a/docs/wallet/abstractionkit/13-safe-unified-account.mdx
+++ b/docs/wallet/abstractionkit/13-safe-unified-account.mdx
@@ -87,7 +87,7 @@ console.log("Account address (sender): " + smartAccount.accountAddress);
 
 #### Source code
 
-[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.7/src/account/Safe/SafeMultiChainSigAccount.ts)
+[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeMultiChainSigAccount.ts#L150)
 
 ### createUserOperation
 
@@ -129,7 +129,7 @@ const userOperation = await smartAccount.createUserOperation(
 
 #### Source code
 
-[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.7/src/account/Safe/SafeMultiChainSigAccount.ts)
+[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeMultiChainSigAccount.ts#L380)
 
 ### signUserOperations
 
@@ -182,13 +182,13 @@ userOp2.signature = signatures[1];
 
 #### Source code
 
-[signUserOperations](https://github.com/candidelabs/abstractionkit/blob/v0.3.7/src/account/Safe/SafeMultiChainSigAccount.ts)
+[signUserOperations](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeMultiChainSigAccount.ts#L541)
 
 ### signUserOperationsWithSigners
 
 Multi-op variant that signs a Merkle-rooted bundle of UserOperations using one or more [`ExternalSigner`s](/wallet/abstractionkit/external-signers) instead of raw private keys. One signing session covers every chain in the bundle.
 
-The Merkle root has no typed-data display, so this path requires a signer that implements `signHash`. `fromViemWalletClient` (typed-data only) fails offline here; use `fromViem`, `fromEthersWallet`, or a custom signer.
+Since `v0.3.8`, this path accepts typed-data-only signers such as `fromViemWalletClient` as well as raw-hash signers. Pass `chainId` inside each `UserOperationToSign` item so the SDK can build the per-chain typed-data payloads.
 
 ```ts title="example.ts"
 import { SafeMultiChainSigAccountV1 as SafeAccount, fromViem } from "abstractionkit";
@@ -244,7 +244,7 @@ const hash = SafeAccount.getMultiChainSingleSignatureUserOperationsEip712Hash([
 
 #### Source code
 
-[getMultiChainSingleSignatureUserOperationsEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.3.7/src/account/Safe/SafeMultiChainSigAccount.ts)
+[getMultiChainSingleSignatureUserOperationsEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeMultiChainSigAccount.ts#L772)
 
 ### getMultiChainSingleSignatureUserOperationsEip712Data
 
@@ -283,7 +283,7 @@ const signature = await wallet.signTypedData(domain, types, messageValue);
 
 #### Source code
 
-[getMultiChainSingleSignatureUserOperationsEip712Data](https://github.com/candidelabs/abstractionkit/blob/v0.3.7/src/account/Safe/SafeMultiChainSigAccount.ts)
+[getMultiChainSingleSignatureUserOperationsEip712Data](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeMultiChainSigAccount.ts#L806)
 
 ### formatSignaturesToUseroperationsSignatures
 
@@ -337,7 +337,7 @@ userOp2.signature = signatures[1];
 
 #### Source code
 
-[formatSignaturesToUseroperationsSignatures](https://github.com/candidelabs/abstractionkit/blob/v0.3.7/src/account/Safe/SafeMultiChainSigAccount.ts)
+[formatSignaturesToUseroperationsSignatures](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeMultiChainSigAccount.ts#L863)
 
 ### sendUserOperation
 

--- a/docs/wallet/abstractionkit/13-safe-unified-account.mdx
+++ b/docs/wallet/abstractionkit/13-safe-unified-account.mdx
@@ -358,7 +358,7 @@ import { CandidePaymaster } from "abstractionkit";
 
 // One paymaster instance per chain
 const paymaster1 = new CandidePaymaster("https://api.candide.dev/public/v3/11155111");
-const paymaster2 = new CandidePaymaster("https://api.candide.dev/public/v3/optimism-sepolia");
+const paymaster2 = new CandidePaymaster("https://api.candide.dev/public/v3/11155420");
 
 // Phase 1: Commit (before signing)
 const commitContext = { signingPhase: "commit" as const };

--- a/docs/wallet/abstractionkit/13-safe-unified-account.mdx
+++ b/docs/wallet/abstractionkit/13-safe-unified-account.mdx
@@ -357,7 +357,7 @@ Use `CandidePaymaster` for gas sponsorship with multichain operations. The payma
 import { CandidePaymaster } from "abstractionkit";
 
 // One paymaster instance per chain
-const paymaster1 = new CandidePaymaster("https://api.candide.dev/public/v3/sepolia");
+const paymaster1 = new CandidePaymaster("https://api.candide.dev/public/v3/11155111");
 const paymaster2 = new CandidePaymaster("https://api.candide.dev/public/v3/optimism-sepolia");
 
 // Phase 1: Commit (before signing)

--- a/docs/wallet/abstractionkit/14-external-signers.mdx
+++ b/docs/wallet/abstractionkit/14-external-signers.mdx
@@ -49,9 +49,9 @@ Each account class exposes its own signing method and accepts a different subset
 |---|---|---|
 | `SafeAccountV0_2_0`, `SafeAccountV0_3_0`, `SafeAccountV1_5_0_M_0_3_0` | `signUserOperationWithSigners(userOperation, signers, chainId)` | `fromViem`, `fromViemWalletClient`, `fromEthersWallet`, `fromPrivateKey`, `fromSafeWebauthn`, custom |
 | `SafeMultiChainSigAccountV1` (single UserOperation) | `signUserOperationWithSigners(userOperation, signers, chainId)` | `fromViem`, `fromViemWalletClient`, `fromEthersWallet`, `fromPrivateKey`, `fromSafeWebauthn`, custom |
-| `SafeMultiChainSigAccountV1` (multi-op Merkle path) | `signUserOperationsWithSigners(userOperationsToSign, signers)` | `fromViem`, `fromEthersWallet`, `fromPrivateKey`, `fromSafeWebauthn`, custom (`signHash` required) |
+| `SafeMultiChainSigAccountV1` (multi-op Merkle path) | `signUserOperationsWithSigners(userOperationsToSign, signers)` | `fromViem`, `fromViemWalletClient`, `fromEthersWallet`, `fromPrivateKey`, `fromSafeWebauthn`, custom |
 | `Simple7702Account`, `Simple7702AccountV09` | `signUserOperationWithSigner(userOperation, signer, chainId)` | `fromViem`, `fromViemWalletClient`, `fromEthersWallet`, `fromPrivateKey`, custom |
-| `Calibur7702Account` | `signUserOperationWithSigner(userOperation, signer, chainId)` | `fromViem`, `fromEthersWallet`, `fromPrivateKey`, custom (`signHash` required) |
+| `Calibur7702Account` | `signUserOperationWithSigner(userOperation, signer, chainId)` | `fromViem`, `fromViemWalletClient`, `fromEthersWallet`, `fromPrivateKey`, custom |
 
 For Safe accounts, pass one signer per owner required by the threshold. For multi-chain Safe signing, pass the UserOperations and chain IDs together:
 
@@ -65,7 +65,7 @@ const signatures = await safe.signUserOperationsWithSigners(
 );
 ```
 
-Under the hood, every signer implements `signHash`, `signTypedData`, or both, and each account picks the scheme it prefers (typed data when supported, so wallets can display structured EIP-712 fields). Capability mismatches throw offline with an actionable error before any wallet prompt is shown. `fromViemWalletClient` is typed-data only, which is why it cannot drive the Calibur or multi-op Merkle paths (both require raw-hash signing). `fromSafeWebauthn` is Safe-specific because it produces an EIP-1271 contract signature using Safe's WebAuthn verifier.
+Under the hood, every signer implements `signHash`, `signTypedData`, or both, and each account picks the scheme it prefers. Since `v0.3.8`, `Simple7702Account`, `Simple7702AccountV09`, `Calibur7702Account`, and `SafeMultiChainSigAccountV1` all accept typed-data-only signers where the account supports EIP-712 signing. Capability mismatches throw offline with an actionable error before any wallet prompt is shown. `fromSafeWebauthn` is Safe-specific because it produces an EIP-1271 contract signature using Safe's WebAuthn verifier.
 
 ## Adapter recipes
 
@@ -92,7 +92,7 @@ Full example: [`signer/fromViem.ts`](https://github.com/candidelabs/abstractionk
 
 ### viem WalletClient
 
-Use `fromViemWalletClient` for browser wallets and injected JSON-RPC wallets. It only exposes `signTypedData`, so it does not work with Calibur or the Safe multi-op Merkle path.
+Use `fromViemWalletClient` for browser wallets and injected JSON-RPC wallets. It exposes `signTypedData`, so it works with Safe accounts, Safe multi-chain signing, Simple7702 accounts, and Calibur.
 
 ```ts
 import { SafeAccountV0_3_0 as SafeAccount, fromViemWalletClient } from "abstractionkit";
@@ -224,7 +224,7 @@ type ExternalSigner = { address: `0x${string}` } & (
 
 The discriminated union enforces at compile time that every signer implements at least one of `signHash` or `signTypedData`. The optional `type` field defaults to `"ecdsa"`. Safe accounts use `"contract"` for dynamic-length EIP-1271 signatures, including WebAuthn verifier contracts.
 
-Canonical source: [`src/signer/types.ts`](https://github.com/candidelabs/abstractionkit/blob/v0.3.7/src/signer/types.ts).
+Canonical source: [`src/signer/types.ts`](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/signer/types.ts#L152).
 
 ## End-to-end examples
 

--- a/docs/wallet/abstractionkit/3.paymaster.mdx
+++ b/docs/wallet/abstractionkit/3.paymaster.mdx
@@ -120,7 +120,7 @@ const { userOperation: sponsoredUserOperation, sponsorMetadata } =
 </Tabs>
 
 #### Source code
-[createSponsorPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/paymaster/CandidePaymaster.ts#L529)
+[createSponsorPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/paymaster/CandidePaymaster.ts#L571)
 
 ### fetchSupportedERC20TokensAndPaymasterMetadata
 
@@ -284,7 +284,7 @@ userOperation = sponsoredUserOperation;
 </details>
 
 #### Source code
-[createTokenPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/paymaster/CandidePaymaster.ts#L570)
+[createTokenPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/paymaster/CandidePaymaster.ts#L612)
 
 ### calculateUserOperationErc20TokenMaxGasCost
 
@@ -331,7 +331,7 @@ const cost = await paymaster.calculateUserOperationErc20TokenMaxGasCost(
 </details>
 
 #### Source code
-[calculateUserOperationErc20TokenMaxGasCost](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/paymaster/CandidePaymaster.ts#L669)
+[calculateUserOperationErc20TokenMaxGasCost](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/paymaster/CandidePaymaster.ts#L711)
 
 ## Advanced Methods
 
@@ -392,7 +392,7 @@ const paymasterResult = await paymaster.getPaymasterMetaData(SafeAccount.DEFAULT
 
 #### source code
 
-[getPaymasterMetaData](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/paymaster/CandidePaymaster.ts#L290)
+[getPaymasterMetaData](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/paymaster/CandidePaymaster.ts#L334)
 
 ### getSupportedEntrypoints
 
@@ -431,7 +431,7 @@ const paymasterResult = await paymaster.getSupportedEntrypoints();
 </details>
 
 #### source code
-[getSupportedEntrypoints](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/paymaster/CandidePaymaster.ts#L269)
+[getSupportedEntrypoints](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/paymaster/CandidePaymaster.ts#L311)
 
 ### isSupportedERC20Token
 
@@ -472,7 +472,7 @@ true
 </details>
 
 #### Source
-[isSupportedERC20Token](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/paymaster/CandidePaymaster.ts#L307)
+[isSupportedERC20Token](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/paymaster/CandidePaymaster.ts#L351)
 
 ### getSupportedERC20TokenData
 
@@ -521,7 +521,7 @@ const erc20TokenData = await paymaster.getSupportedERC20TokenData(erc20TokenAddr
 </details>
 
 #### Source code
-[getSupportedERC20TokenData](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/paymaster/CandidePaymaster.ts#L323)
+[getSupportedERC20TokenData](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/paymaster/CandidePaymaster.ts#L367)
 
 ### fetchTokenPaymasterExchangeRate
 
@@ -564,7 +564,7 @@ const exchangeRate = await paymaster.fetchTokenPaymasterExchangeRate(erc20TokenA
 </details>
 
 #### Source code
-[fetchTokenPaymasterExchangeRate](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/paymaster/CandidePaymaster.ts#L706)
+[fetchTokenPaymasterExchangeRate](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/paymaster/CandidePaymaster.ts#L748)
 
 ### createPaymasterUserOperation
 
@@ -573,7 +573,7 @@ const exchangeRate = await paymaster.fetchTokenPaymasterExchangeRate(erc20TokenA
 :::
 
 #### Source code
-[createPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/paymaster/CandidePaymaster.ts#L486)
+[createPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/paymaster/CandidePaymaster.ts#L530)
 
 ## Erc7677Paymaster
 
@@ -637,4 +637,4 @@ userOperation = tokenOp2;
 ```
 
 #### Source code
-[Erc7677Paymaster](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/paymaster/Erc7677Paymaster.ts)
+[Erc7677Paymaster](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/paymaster/Erc7677Paymaster.ts#L186)

--- a/docs/wallet/abstractionkit/3.paymaster.mdx
+++ b/docs/wallet/abstractionkit/3.paymaster.mdx
@@ -64,7 +64,7 @@ Initialize a Paymaster with your RPC URL. Get an API key from the [dashboard](ht
 ```ts title="paymaster.ts"
 import { CandidePaymaster } from "abstractionkit";
 
-const paymasterRPC = "https://api.candide.dev/public/v3/sepolia";
+const paymasterRPC = "https://api.candide.dev/public/v3/11155111";
 const paymaster: CandidePaymaster = new CandidePaymaster(paymasterRPC);
 ```
 
@@ -92,7 +92,7 @@ Returns the paymaster data if the the userOperation has a Gas Policy. Otherwise 
 ```ts title="example.ts"
 import { CandidePaymaster } from "abstractionkit";
 
-const paymasterRPC = "https://api.candide.dev/public/v3/sepolia";
+const paymasterRPC = "https://api.candide.dev/public/v3/11155111";
 const paymaster: CandidePaymaster = new CandidePaymaster(paymasterRPC);
 const sponsorshipPolicyId = '1234';
 
@@ -134,7 +134,7 @@ Returns a promise with the supported erc20 tokens and their exchange rate, along
 ```ts title="example.ts"
 import { CandidePaymaster, SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
 
-const paymasterRPC="https://api.candide.dev/public/v3/sepolia";
+const paymasterRPC="https://api.candide.dev/public/v3/11155111";
 const paymaster = new CandidePaymaster(paymasterRPC);
 
 const supportedERC20Tokens = await paymaster.fetchSupportedERC20TokensAndPaymasterMetadata(SafeAccount.DEFAULT_ENTRYPOINT_ADDRESS);
@@ -217,9 +217,9 @@ The `overrides` parameter also accepts an `entrypoint` field, which allows you t
 ```ts
 import { SafeAccountV0_3_0 as SafeAccount, CandidePaymaster } from "abstractionkit";
 
-const paymasterRPC="https://api.candide.dev/public/v3/sepolia";
+const paymasterRPC="https://api.candide.dev/public/v3/11155111";
 const erc20TokenAddress = "0xFa5854FBf9964330d761961F46565AB7326e5a3b"; // CTT test token
-const bundlerRPC = "https://api.candide.dev/public/v3/sepolia";
+const bundlerRPC = "https://api.candide.dev/public/v3/11155111";
 
 const ownerPublicAddress = "0x2Ef844456580b6e1E22e1D584EBbC2467D9298B2"
 const smartAccount = SafeAccount.initializeNewAccount([ownerPublicAddress])
@@ -302,7 +302,7 @@ const erc20TokenAddress = "0xFa5854FBf9964330d761961F46565AB7326e5a3b"; // CTT t
 // Use createUserOperation() to help you construct a userOp
 const userOperation = smartAccount.createUserOperation(..)
 
-const paymasterRPC="https://api.candide.dev/public/v3/sepolia";
+const paymasterRPC="https://api.candide.dev/public/v3/11155111";
 const paymaster: CandidePaymaster = new CandidePaymaster(paymasterRPC);
 
 // highlight-start
@@ -347,7 +347,7 @@ Returns the metadata associated with the Paymaster, along with dummyPaymasterAnd
 ```ts title="example.ts"
 import { CandidePaymaster, SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
 
-const paymasterRPC="https://api.candide.dev/public/v3/sepolia";
+const paymasterRPC="https://api.candide.dev/public/v3/11155111";
 const paymaster: CandidePaymaster = new CandidePaymaster(paymasterRPC);
 
 const paymasterResult = await paymaster.getPaymasterMetaData(SafeAccount.DEFAULT_ENTRYPOINT_ADDRESS);
@@ -406,7 +406,7 @@ Returns the supported Entrypoints by the paymaster
 ```ts title="example.ts"
 import { CandidePaymaster } from "abstractionkit";
 
-const paymasterRPC="https://api.candide.dev/public/v3/sepolia";
+const paymasterRPC="https://api.candide.dev/public/v3/11155111";
 const paymaster: CandidePaymaster = new CandidePaymaster(paymasterRPC);
 
 const paymasterResult = await paymaster.getSupportedEntrypoints();
@@ -444,7 +444,7 @@ Checks if a particular ERC-20 token is accepted as gas payment by the paymaster.
 ```ts title="example.ts"
 import { CandidePaymaster } from "abstractionkit";
 
-const paymasterRPC="https://api.candide.dev/public/v3/sepolia";
+const paymasterRPC="https://api.candide.dev/public/v3/11155111";
 const paymaster: CandidePaymaster = new CandidePaymaster(paymasterRPC);
 
 const erc20TokenAddress = "0xFa5854FBf9964330d761961F46565AB7326e5a3b"; // CTT on sepolia testnet
@@ -486,7 +486,7 @@ Returns the token data given an erc20 address
 ```ts title="example.ts"
 import { CandidePaymaster } from "abstractionkit";
 
-const paymasterRPC = "https://api.candide.dev/public/v3/sepolia";
+const paymasterRPC = "https://api.candide.dev/public/v3/11155111";
 
 const erc20TokenAddress = "0xFa5854FBf9964330d761961F46565AB7326e5a3b";
 const paymaster: CandidePaymaster = new CandidePaymaster(paymasterRPC);
@@ -535,7 +535,7 @@ Fetches the current exchange rate for an ERC-20 token from the paymaster. The ex
 ```ts title="example.ts"
 import { CandidePaymaster } from "abstractionkit";
 
-const paymasterRPC = "https://api.candide.dev/public/v3/sepolia";
+const paymasterRPC = "https://api.candide.dev/public/v3/11155111";
 const paymaster: CandidePaymaster = new CandidePaymaster(paymasterRPC);
 
 const erc20TokenAddress = "0xFa5854FBf9964330d761961F46565AB7326e5a3b"; // CTT on sepolia testnet
@@ -594,7 +594,7 @@ import { Erc7677Paymaster } from "abstractionkit";
 ```ts title="example.ts"
 import { Erc7677Paymaster } from "abstractionkit";
 
-const bundlerRpc = "https://api.candide.dev/public/v3/sepolia";
+const bundlerRpc = "https://api.candide.dev/public/v3/11155111";
 const paymaster = new Erc7677Paymaster(bundlerRpc);
 
 // Use createUserOperation() to help you construct a userOp
@@ -614,7 +614,7 @@ userOperation = sponsoredOp;
 Passing `{ token }` in the context triggers the ERC-20 gas flow automatically. For Candide and Pimlico the exchange rate is fetched for you; for unknown providers, supply `exchangeRate` in the context. `tokenQuote` surfaces the exchange rate and max token cost applied to the UserOperation so you can display the charge to the user without a second round trip.
 
 ```ts title="example.ts"
-const bundlerRpc = "https://api.candide.dev/public/v3/sepolia";
+const bundlerRpc = "https://api.candide.dev/public/v3/11155111";
 const usdcAddress = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"; // USDC on sepolia
 
 // Candide or Pimlico (auto-detected): exchange rate fetched from the RPC

--- a/docs/wallet/abstractionkit/4.utilities.mdx
+++ b/docs/wallet/abstractionkit/4.utilities.mdx
@@ -18,11 +18,6 @@ import {
   fetchAccountNonceReturn,
   calculateUserOperationMaxGasCostParams,
   calculateUserOperationMaxGasCostReturn,
-  getBalanceOfParams,
-  getBalanceOfReturn,
-  getDepositInfoParams,
-  getDepositInfoReturn,
-  depositInfoType,
   simulateUserOperationWithTenderlyParams,
   simulateUserOperationWithTenderlyReturn,
   simulateUserOperationCallDataWithTenderlyParams,
@@ -34,20 +29,12 @@ import {
   metaTransactionType,
   decodeMultiSendCallDataParams,
   decodeMultiSendCallDataReturn,
-  fetchGasPriceParams,
-  fetchGasPriceReturn,
   createCallDataParams,
   createCallDataReturn,
   getFunctionSelectorParams,
   getFunctionSelectorReturn,
   sendJsonRpcRequestParams,
   sendJsonRpcRequestReturn,
-  sendEthCallRequestParams,
-  sendEthCallRequestReturn,
-  sendEthGetCodeRequestParams,
-  sendEthGetCodeRequestReturn,
-  getDelegatedAddressParams,
-  getDelegatedAddressReturn,
   createAndSignEip7702DelegationAuthorizationParams,
   createAndSignEip7702DelegationAuthorizationReturn,
   authorization7702HexReturnType,
@@ -94,7 +81,7 @@ const userOpHash = createUserOperationHash(
 </Tabs>
 
 #### Source code
-[createUserOperationHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utils.ts)
+[createUserOperationHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils.ts#L50)
 
 ### createPackedUserOperationV6
 
@@ -119,7 +106,7 @@ const packed = createPackedUserOperationV6(userOperationV6);
 </Tabs>
 
 #### Source code
-[createPackedUserOperationV6](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utils.ts)
+[createPackedUserOperationV6](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils.ts#L313)
 
 ### createPackedUserOperationV7
 
@@ -144,7 +131,7 @@ const packed = createPackedUserOperationV7(userOperationV7);
 </Tabs>
 
 #### Source code
-[createPackedUserOperationV7](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utils.ts)
+[createPackedUserOperationV7](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils.ts#L353)
 
 ### fetchAccountNonce
 
@@ -173,7 +160,7 @@ const nonce = await fetchAccountNonce(
 </Tabs>
 
 #### Source code
-[fetchAccountNonce](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utils.ts)
+[fetchAccountNonce](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils.ts#L586)
 
 ### calculateUserOperationMaxGasCost
 
@@ -198,67 +185,95 @@ const maxCost = calculateUserOperationMaxGasCost(userOperation);
 </Tabs>
 
 #### Source code
-[calculateUserOperationMaxGasCost](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utils.ts)
+[calculateUserOperationMaxGasCost](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils.ts#L645)
+
+### JsonRpcNode
+
+`JsonRpcNode` wraps common Ethereum node calls behind the same `Transport` abstraction used by Bundler and Paymaster services. Use it for node reads instead of the removed top-level URL helpers `fetchGasPrice`, `getBalanceOf`, `getDepositInfo`, and `getDelegatedAddress`.
+
+<Tabs>
+<TabItem value="example.ts" label="example.ts">
+
+```ts title="example.ts"
+import { GasOption, JsonRpcNode } from "abstractionkit";
+
+const node = new JsonRpcNode("https://ethereum-sepolia-rpc.publicnode.com");
+
+const [maxFeePerGas, maxPriorityFeePerGas] = await node.getFeeData(GasOption.Medium);
+const deposit = await node.getEntryPointDeposit(
+  "0xYourAccountAddress",
+  "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+);
+const depositInfo = await node.getEntryPointDepositInfo(
+  "0xYourAccountAddress",
+  "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+);
+const delegatee = await node.getDelegatedAddress("0xYourEOAAddress");
+```
+
+</TabItem>
+<TabItem value="Transport" label="Transport">
+
+```ts title="transport.ts"
+import { JsonRpcNode, type Transport } from "abstractionkit";
+
+const transport: Transport = {
+  request: async ({ method, params }, options) => {
+    return myRpcClient.request({ method, params }, { signal: options?.signal });
+  },
+};
+
+const node = new JsonRpcNode(transport);
+const code = await node.getCode("0xYourAccountAddress");
+```
+
+</TabItem>
+</Tabs>
+
+#### Methods
+
+- `chainId()`
+- `blockNumber()`
+- `getCode(address)`
+- `call(transaction)`
+- `getTransactionCount(address)`
+- `getFeeData(gasOption?)`
+- `getDelegatedAddress(eoaAddress)`
+- `getEntryPointNonce(entryPoint, account, key?)`
+- `getEntryPointDeposit(address, entryPoint)`
+- `getEntryPointDepositInfo(address, entryPoint)`
+- `request(args, options?)`
+
+#### Source code
+[JsonRpcNode](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/transport/JsonRpcNode.ts#L50)
 
 ### getBalanceOf
 
-Returns the balance of an account deposited in the EntryPoint contract.
+Deprecated in `v0.3.8`. Use `JsonRpcNode#getEntryPointDeposit` instead.
 
-<Tabs>
-<TabItem value="example.ts" label="example.ts">
+```ts title="migration.ts"
+import { JsonRpcNode } from "abstractionkit";
 
-```ts title="example.ts"
-import { getBalanceOf } from "abstractionkit";
-
-const balance = await getBalanceOf(
-  "https://ethereum-sepolia-rpc.publicnode.com",
+const node = new JsonRpcNode("https://ethereum-sepolia-rpc.publicnode.com");
+const balance = await node.getEntryPointDeposit(
   "0xYourAccountAddress",
-  "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
+  "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
 );
 ```
-
-</TabItem>
-<TabItem value="Param Types" label="Param Types">
-  <DataTable items={getBalanceOfParams} />
-</TabItem>
-<TabItem value="Return Type" label="Return Type">
-  <DataTable items={getBalanceOfReturn} />
-</TabItem>
-</Tabs>
-
-#### Source code
-[getBalanceOf](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utils.ts)
 
 ### getDepositInfo
 
-Returns the full deposit information of an account in the EntryPoint contract, including deposit balance, stake status, and unstake delay.
+Deprecated in `v0.3.8`. Use `JsonRpcNode#getEntryPointDepositInfo` instead.
 
-<Tabs>
-<TabItem value="example.ts" label="example.ts">
+```ts title="migration.ts"
+import { JsonRpcNode } from "abstractionkit";
 
-```ts title="example.ts"
-import { getDepositInfo } from "abstractionkit";
-
-const info = await getDepositInfo(
-  "https://ethereum-sepolia-rpc.publicnode.com",
+const node = new JsonRpcNode("https://ethereum-sepolia-rpc.publicnode.com");
+const info = await node.getEntryPointDepositInfo(
   "0xYourAccountAddress",
-  "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
+  "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
 );
 ```
-
-</TabItem>
-<TabItem value="Param Types" label="Param Types">
-  <DataTable items={getDepositInfoParams} />
-</TabItem>
-<TabItem value="Return Type" label="Return Type">
-  <DataTable items={getDepositInfoReturn} />
-  DepositInfo
-  <DataTable items={depositInfoType} />
-</TabItem>
-</Tabs>
-
-#### Source code
-[getDepositInfo](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utils.ts)
 
 ## Simulation utils
 
@@ -293,7 +308,7 @@ const { simulation, simulationShareLink } =
 </Tabs>
 
 #### Source code
-[simulateUserOperationWithTenderlyAndCreateShareLink](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utilsTenderly.ts)
+[simulateUserOperationWithTenderlyAndCreateShareLink](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utilsTenderly.ts#L82)
 
 ### simulateUserOperationCallDataWithTenderlyAndCreateShareLink
 
@@ -326,7 +341,7 @@ const { simulation, callDataSimulationShareLink } =
 </Tabs>
 
 #### Source code
-[simulateUserOperationCallDataWithTenderlyAndCreateShareLink](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utilsTenderly.ts)
+[simulateUserOperationCallDataWithTenderlyAndCreateShareLink](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utilsTenderly.ts#L376)
 
 ### simulateSenderCallDataWithTenderlyAndCreateShareLink
 
@@ -360,7 +375,7 @@ const { simulation, callDataSimulationShareLink } =
 </Tabs>
 
 #### Source code
-[simulateSenderCallDataWithTenderlyAndCreateShareLink](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utilsTenderly.ts)
+[simulateSenderCallDataWithTenderlyAndCreateShareLink](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utilsTenderly.ts#L596)
 
 ## Multicall utils
 
@@ -402,7 +417,7 @@ const callData = encodeMultiSendCallData([
 </Tabs>
 
 #### Source code
-[encodeMultiSendCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/multisend.ts)
+[encodeMultiSendCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/multisend.ts#L26)
 
 ### decodeMultiSendCallData
 
@@ -427,37 +442,20 @@ const decoded = decodeMultiSendCallData(encodedCallData);
 </Tabs>
 
 #### Source code
-[decodeMultiSendCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/multisend.ts)
+[decodeMultiSendCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/multisend.ts#L36)
 
 ## Generic Ethereum utils
 
 ### fetchGasPrice
 
-Fetches the current gas price from an Ethereum node, returning maxFeePerGas and maxPriorityFeePerGas for a given gas level.
+Deprecated in `v0.3.8`. Use `JsonRpcNode#getFeeData` instead.
 
-<Tabs>
-<TabItem value="example.ts" label="example.ts">
+```ts title="migration.ts"
+import { GasOption, JsonRpcNode } from "abstractionkit";
 
-```ts title="example.ts"
-import { fetchGasPrice, GasOption } from "abstractionkit";
-
-const [maxFeePerGas, maxPriorityFeePerGas] = await fetchGasPrice(
-  "https://ethereum-sepolia-rpc.publicnode.com",
-  GasOption.Medium
-);
+const node = new JsonRpcNode("https://ethereum-sepolia-rpc.publicnode.com");
+const [maxFeePerGas, maxPriorityFeePerGas] = await node.getFeeData(GasOption.Medium);
 ```
-
-</TabItem>
-<TabItem value="Param Types" label="Param Types">
-  <DataTable items={fetchGasPriceParams} />
-</TabItem>
-<TabItem value="Return Type" label="Return Type">
-  <DataTable items={fetchGasPriceReturn} />
-</TabItem>
-</Tabs>
-
-#### Source code
-[fetchGasPrice](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utils.ts)
 
 ### createCallData
 
@@ -486,7 +484,7 @@ const callData = createCallData(
 </Tabs>
 
 #### Source code
-[createCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utils.ts)
+[createCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils.ts#L474)
 
 ### getFunctionSelector
 
@@ -512,7 +510,7 @@ const selector = getFunctionSelector("transfer(address,uint256)");
 </Tabs>
 
 #### Source code
-[getFunctionSelector](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utils.ts)
+[getFunctionSelector](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils.ts#L567)
 
 ### sendJsonRpcRequest
 
@@ -541,83 +539,48 @@ const result = await sendJsonRpcRequest(
 </Tabs>
 
 #### Source code
-[sendJsonRpcRequest](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utils.ts)
+[sendJsonRpcRequest](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils.ts#L514)
 
 ### sendEthCallRequest
 
-Executes an `eth_call` against an Ethereum node and returns the result. Useful for reading contract state without submitting a transaction.
-
-<Tabs>
-<TabItem value="example.ts" label="example.ts">
+Deprecated in `v0.3.8`. Use `JsonRpcNode#call` instead.
 
 ```ts title="example.ts"
-import { sendEthCallRequest } from "abstractionkit";
+import { JsonRpcNode } from "abstractionkit";
 
-const result = await sendEthCallRequest(
-  "https://ethereum-sepolia-rpc.publicnode.com",
-  {
-    to: "0xContractAddress",
-    data: "0xCallData",
-  },
-  "latest"
-);
+const node = new JsonRpcNode("https://ethereum-sepolia-rpc.publicnode.com");
+const result = await node.call({
+  to: "0xContractAddress",
+  data: "0xCallData",
+});
 ```
 
-</TabItem>
-<TabItem value="Param Types" label="Param Types">
-  <DataTable items={sendEthCallRequestParams} />
-</TabItem>
-<TabItem value="Return Type" label="Return Type">
-  <DataTable items={sendEthCallRequestReturn} />
-</TabItem>
-</Tabs>
-
 #### Source code
-[sendEthCallRequest](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utils.ts)
+[JsonRpcNode.call](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/transport/JsonRpcNode.ts#L163)
 
 ### sendEthGetCodeRequest
 
-Retrieves the bytecode deployed at a given contract address using `eth_getCode`.
-
-<Tabs>
-<TabItem value="example.ts" label="example.ts">
+Deprecated in `v0.3.8`. Use `JsonRpcNode#getCode` instead.
 
 ```ts title="example.ts"
-import { sendEthGetCodeRequest } from "abstractionkit";
+import { JsonRpcNode } from "abstractionkit";
 
-const code = await sendEthGetCodeRequest(
-  "https://ethereum-sepolia-rpc.publicnode.com",
-  "0xContractAddress",
-  "latest"
-);
+const node = new JsonRpcNode("https://ethereum-sepolia-rpc.publicnode.com");
+const code = await node.getCode("0xContractAddress");
 ```
 
-</TabItem>
-<TabItem value="Param Types" label="Param Types">
-  <DataTable items={sendEthGetCodeRequestParams} />
-</TabItem>
-<TabItem value="Return Type" label="Return Type">
-  <DataTable items={sendEthGetCodeRequestReturn} />
-</TabItem>
-</Tabs>
-
 #### Source code
-[sendEthGetCodeRequest](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utils.ts)
+[JsonRpcNode.getCode](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/transport/JsonRpcNode.ts#L137)
 
 ### getDelegatedAddress
 
-Checks whether an EOA has an active EIP-7702 delegation and returns the delegated address, or null if the account is not delegated.
+Deprecated in `v0.3.8`. Use `JsonRpcNode#getDelegatedAddress` instead.
 
-<Tabs>
-<TabItem value="example.ts" label="example.ts">
+```ts title="migration.ts"
+import { JsonRpcNode } from "abstractionkit";
 
-```ts title="example.ts"
-import { getDelegatedAddress } from "abstractionkit";
-
-const delegatee = await getDelegatedAddress(
-  "0xYourEOAAddress",
-  "https://ethereum-sepolia-rpc.publicnode.com"
-);
+const node = new JsonRpcNode("https://ethereum-sepolia-rpc.publicnode.com");
+const delegatee = await node.getDelegatedAddress("0xYourEOAAddress");
 
 if (delegatee) {
   console.log("Delegated to:", delegatee);
@@ -625,18 +588,6 @@ if (delegatee) {
   console.log("Not delegated");
 }
 ```
-
-</TabItem>
-<TabItem value="Param Types" label="Param Types">
-  <DataTable items={getDelegatedAddressParams} />
-</TabItem>
-<TabItem value="Return Type" label="Return Type">
-  <DataTable items={getDelegatedAddressReturn} />
-</TabItem>
-</Tabs>
-
-#### Source code
-[getDelegatedAddress](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utils.ts)
 
 ## EIP-7702 Utilities
 
@@ -682,7 +633,7 @@ const authorization = await createAndSignEip7702DelegationAuthorization(
 </Tabs>
 
 #### Source code
-[createAndSignEip7702DelegationAuthorization](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utils7702.ts)
+[createAndSignEip7702DelegationAuthorization](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils7702.ts#L137)
 
 ### createRevokeDelegationAuthorization
 
@@ -713,7 +664,7 @@ const revokeAuth = createRevokeDelegationAuthorization(
 </Tabs>
 
 #### Source code
-[createRevokeDelegationAuthorization](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utils7702.ts)
+[createRevokeDelegationAuthorization](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils7702.ts#L192)
 
 ### createEip7702DelegationAuthorizationHash
 
@@ -742,7 +693,7 @@ const hash = createEip7702DelegationAuthorizationHash(
 </Tabs>
 
 #### Source code
-[createEip7702DelegationAuthorizationHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utils7702.ts)
+[createEip7702DelegationAuthorizationHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils7702.ts#L209)
 
 ### createAndSignEip7702RawTransaction
 
@@ -779,7 +730,7 @@ const rawTx = createAndSignEip7702RawTransaction(
 </Tabs>
 
 #### Source code
-[createAndSignEip7702RawTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utils7702.ts)
+[createAndSignEip7702RawTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils7702.ts#L255)
 
 ### createEip7702TransactionHash
 
@@ -815,4 +766,4 @@ const txHash = createEip7702TransactionHash(
 </Tabs>
 
 #### Source code
-[createEip7702TransactionHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/utils7702.ts)
+[createEip7702TransactionHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils7702.ts#L319)

--- a/docs/wallet/abstractionkit/7-safe-account-v2.mdx
+++ b/docs/wallet/abstractionkit/7-safe-account-v2.mdx
@@ -223,7 +223,7 @@ This example mints the same NFT twice in a single UserOperation.
 import { MetaTransaction } from "abstractionkit";
 
 const jsonRpcNodeProvider = "https://rpc2.sepolia.org";
-const bundlerUrl = "https://api.candide.dev/public/v3/sepolia";
+const bundlerUrl = "https://api.candide.dev/public/v3/11155111";
 
 const transaction: MetaTransaction = {
     to: "0xD9de104e3386d9A45a61BcE269c43E48B534e4E7", // NFT contract address
@@ -454,7 +454,7 @@ console.log("receipt: ", receipt);
 ```terminal
 sendUserOperationResponse: {
   userOperationHash: '0x61b3e2c57ad7ad1ae788f0ac84c79b28aab8aeaf872be173cadc72ab8b3d4418',
-  bundler: { rpcUrl: 'https://api.candide.dev/public/v3/sepolia' },
+  bundler: { rpcUrl: 'https://api.candide.dev/public/v3/11155111' },
   entrypointAddress: '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789'
 }
 
@@ -821,7 +821,7 @@ import {
   UserOperationV6
 } from "abstractionkit";
 
-const bundlerRPC = "https://api.candide.dev/public/v3/sepolia";
+const bundlerRPC = "https://api.candide.dev/public/v3/11155111";
 
 const ownerPublicAddress = "0xBdbc5FBC9cA8C3F514D073eC3de840Ac84FC6D31";
 const smartAccount = SafeAccount.initializeNewAccount([ownerPublicAddress])

--- a/docs/wallet/abstractionkit/7-safe-account-v2.mdx
+++ b/docs/wallet/abstractionkit/7-safe-account-v2.mdx
@@ -116,7 +116,7 @@ const smartAccount = new SafeAccount(accountAddress);
 
 #### Source code
 
-[constructor](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccountV0_2_0.ts#L46)
+[constructor](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L44)
 
 ## Methods
 
@@ -168,7 +168,7 @@ Account address(sender) : 0x1a02592A3484c2077d2E5D24482497F85e1980C6
 
 #### Source code
 
-[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccountV0_2_0.ts#L111)
+[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L109)
 
 ### isDeployed
 
@@ -206,7 +206,7 @@ const account = (await SafeAccount.isDeployed(accountAddress, nodeRpcUrl))
 
 #### Source code
 
-[isDeployed](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccount.ts#L256)
+[isDeployed](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccount.ts#L257)
 
 ### createUserOperation
 
@@ -344,7 +344,7 @@ console.log(userOperation);
 </details>
 
 #### Source code
-[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccountV0_2_0.ts#L324)
+[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L322)
 
 ### signUserOperation
 
@@ -390,7 +390,7 @@ console.log(signature);
 </details>
 
 #### Source code
-[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccountV0_2_0.ts#L458)
+[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L456)
 
 ### signUserOperationWithSigners
 
@@ -412,7 +412,7 @@ userOperation.signature = await smartAccount.signUserOperationWithSigners(
 See [External Signers](/wallet/abstractionkit/external-signers) for the full list of adapters and custom-signer integrations.
 
 #### Source code
-[signUserOperationWithSigners](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccount.ts)
+[signUserOperationWithSigners](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L483)
 
 ### sendUserOperation
 
@@ -488,7 +488,7 @@ receipt: {
 </details>
 
 #### Source code
-[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccount.ts#L988)
+[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccount.ts#L989)
 
 ## Advanced Methods
 
@@ -542,7 +542,7 @@ Account address(sender) : 0x1a02592A3484c2077d2E5D24482497F85e1980C6
 
 #### Source code
 
-[createAccountAddress](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccountV0_2_0.ts#L74)
+[createAccountAddress](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L72)
 
 ### createInitCode
 
@@ -591,7 +591,7 @@ initCode: 0x...
 
 #### Source code
 
-[createInitCode](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccountV0_2_0.ts#L296)
+[createInitCode](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L294)
 
 ### createAccountAddressAndInitCode
 
@@ -643,7 +643,7 @@ initCode: 0x...
 
 #### Source code
 
-[createAccountAddressAndInitCode](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccountV0_2_0.ts#L235)
+[createAccountAddressAndInitCode](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L233)
 
 ### createInitializerCallData
 
@@ -686,7 +686,7 @@ initializeCallData: 0xb63e800d00000000000000000000000000000000000000000000000000
 </details>
 
 #### Source code
-[createInitializerCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccountV0_2_0.ts#L260)
+[createInitializerCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L258)
 
 ### createAccountCallDataSingleTransaction
 
@@ -739,7 +739,7 @@ callData : 0xf34308ef000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2
 
 #### Source code
 
-[createAccountCallDataSingleTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccount.ts#L273)
+[createAccountCallDataSingleTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccount.ts#L274)
 
 ### createAccountCallDataBatchTransactions
 
@@ -804,7 +804,7 @@ callData : 0xf34308ef000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2
 
 #### Source code
 
-[createAccountCallDataBatchTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccount.ts#L308)
+[createAccountCallDataBatchTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccount.ts#L309)
 
 ### estimateUserOperationGas
 
@@ -877,7 +877,7 @@ const [preVerificationGas, verificationGasLimit, callGasLimit] = await estimateU
 </details>
 
 #### Source code
-[estimateUserOperationGas](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccountV0_2_0.ts#L427)
+[estimateUserOperationGas](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L425)
 
 ### getUserOperationEip712Hash
 
@@ -914,7 +914,7 @@ console.log(safeUserOpHash);
 
 #### Source code
 
-[getUserOperationEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccountV0_2_0.ts#L165)
+[getUserOperationEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L163)
 
 ### formatEip712SignaturesToUseroperationSignature
 
@@ -990,7 +990,7 @@ userOperation.signature = formatedSig;
 </details>
 
 #### Source code
-[formatEip712SignaturesToUseroperationSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccount.ts#L515)
+[formatEip712SignaturesToUseroperationSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccount.ts#L516)
 
 ### isModuleEnabled
 
@@ -1118,7 +1118,7 @@ const userOperation = await smartAccount.createUserOperation(
 
 #### Source code
 
-[createMigrateToSafeAccountV0_3_0MetaTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccountV0_2_0.ts#L370)
+[createMigrateToSafeAccountV0_3_0MetaTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L368)
 
 ## Audits
 - [Audits by Ackee and OpenZeppelin](https://github.com/safe-global/safe-modules/blob/main/modules/4337/docs/v0.2.0/audit.md)

--- a/docs/wallet/abstractionkit/8-safe-account-v3.mdx
+++ b/docs/wallet/abstractionkit/8-safe-account-v3.mdx
@@ -135,7 +135,7 @@ Account address(sender) : 0x1a02592A3484c2077d2E5D24482497F85e1980C6
 
 #### Source code
 
-[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccountV0_3_0.ts#L98)
+[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_3_0.ts#L96)
 
 ### isDeployed
 
@@ -173,7 +173,7 @@ const account = (await SafeAccount.isDeployed(accountAddress, nodeRpcUrl))
 
 #### Source code
 
-[isDeployed](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccount.ts#L256)
+[isDeployed](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccount.ts#L257)
 
 ### createUserOperation
 
@@ -315,7 +315,7 @@ console.log(userOperation);
 </details>
 
 #### Source code
-[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccountV0_3_0.ts#L290)
+[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_3_0.ts#L288)
 
 ### signUserOperation
 
@@ -363,7 +363,7 @@ console.log(signature);
 </details>
 
 #### Source code
-[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccountV0_3_0.ts#L357)
+[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_3_0.ts#L355)
 
 ### signUserOperationWithSigners
 
@@ -385,7 +385,7 @@ userOperation.signature = await smartAccount.signUserOperationWithSigners(
 See [External Signers](/wallet/abstractionkit/external-signers) for the full list of adapters and custom-signer integrations.
 
 #### Source code
-[signUserOperationWithSigners](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccount.ts)
+[signUserOperationWithSigners](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_3_0.ts#L394)
 
 ### sendUserOperation
 
@@ -461,7 +461,7 @@ receipt: {
 </details>
 
 #### Source code
-[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccount.ts#L988)
+[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccount.ts#L989)
 
 ## Advanced Methods
 
@@ -515,7 +515,7 @@ Account address(sender) : 0x1a02592A3484c2077d2E5D24482497F85e1980C6
 
 #### Source code
 
-[createAccountAddress](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccountV0_3_0.ts#L75)
+[createAccountAddress](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_3_0.ts#L73)
 
 ### createFactoryAddressAndData
 
@@ -567,7 +567,7 @@ factoryData:  0x1688f0b900000000000000000000000029fcb43b46531bca003ddc8fcb67ffe9
 
 #### Source code
 
-[createFactoryAddressAndData](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccountV0_3_0.ts#L260)
+[createFactoryAddressAndData](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_3_0.ts#L258)
 
 ### createInitializerCallData
 
@@ -610,7 +610,7 @@ initializeCallData: 0xb63e800d00000000000000000000000000000000000000000000000000
 </details>
 
 #### Source
-[createInitializerCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccountV0_3_0.ts#L224)
+[createInitializerCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_3_0.ts#L222)
 
 ### createAccountCallDataSingleTransaction
 
@@ -663,7 +663,7 @@ callData : 0xf34308ef000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2
 
 #### Source code
 
-[createAccountCallDataSingleTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccount.ts#L273)
+[createAccountCallDataSingleTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccount.ts#L274)
 
 ### createAccountCallDataBatchTransactions
 
@@ -728,7 +728,7 @@ callData : 0xf34308ef000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2
 
 #### Source code
 
-[createAccountCallDataBatchTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccount.ts#L308)
+[createAccountCallDataBatchTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccount.ts#L309)
 
 ### estimateUserOperationGas
 
@@ -801,7 +801,7 @@ const [preVerificationGas, verificationGasLimit, callGasLimit] = await estimateU
 </details>
 
 #### Source code
-[estimateUserOperationGas](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccountV0_3_0.ts#L326)
+[estimateUserOperationGas](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_3_0.ts#L324)
 
 ### getUserOperationEip712Hash
 
@@ -845,7 +845,7 @@ console.log(safeUserOpHash);
 </details>
 
 #### Source
-[getUserOperationEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccountV0_3_0.ts#L152)
+[getUserOperationEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_3_0.ts#L150)
 
 ### formatEip712SignaturesToUseroperationSignature
 
@@ -921,7 +921,7 @@ userOperation.signature = formatedSig;
 </details>
 
 #### Source code
-[formatEip712SignaturesToUseroperationSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccount.ts#L515)
+[formatEip712SignaturesToUseroperationSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccount.ts#L516)
 
 
 ### isModuleEnabled

--- a/docs/wallet/abstractionkit/8-safe-account-v3.mdx
+++ b/docs/wallet/abstractionkit/8-safe-account-v3.mdx
@@ -190,7 +190,7 @@ This example mints the same NFT twice in a single UserOperation.
 import { MetaTransaction } from "abstractionkit";
 
 const jsonRpcNodeProvider = "https://rpc2.sepolia.org";
-const bundlerUrl = "https://api.candide.dev/public/v3/sepolia";
+const bundlerUrl = "https://api.candide.dev/public/v3/11155111";
 
 const transaction: MetaTransaction = {
     to: "0xD9de104e3386d9A45a61BcE269c43E48B534e4E7", // NFT contract address
@@ -427,7 +427,7 @@ console.log("receipt: ", receipt);
 ```terminal
 sendUserOperationResponse: {
   userOperationHash: '0x61b3e2c57ad7ad1ae788f0ac84c79b28aab8aeaf872be173cadc72ab8b3d4418',
-  bundler: { rpcUrl: 'https://api.candide.dev/public/v3/sepolia' },
+  bundler: { rpcUrl: 'https://api.candide.dev/public/v3/11155111' },
   entrypointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032'
 }
 
@@ -745,7 +745,7 @@ import {
   UserOperationV7
 } from "abstractionkit";
 
-const bundlerRPC = "https://api.candide.dev/public/v3/sepolia";
+const bundlerRPC = "https://api.candide.dev/public/v3/11155111";
 
 const ownerPublicAddress = "0xBdbc5FBC9cA8C3F514D073eC3de840Ac84FC6D31";
 const smartAccount = SafeAccount.initializeNewAccount([ownerPublicAddress])

--- a/docs/wallet/guides/0-getting-started.mdx
+++ b/docs/wallet/guides/0-getting-started.mdx
@@ -66,9 +66,9 @@ Create a `.env` file in your project root:
 
 ```bash title=".env"
 CHAIN_ID=11155111
-BUNDLER_URL=https://api.candide.dev/public/v3/sepolia
+BUNDLER_URL=https://api.candide.dev/public/v3/11155111
 JSON_RPC_NODE_PROVIDER=https://ethereum-sepolia-rpc.publicnode.com
-PAYMASTER_URL=https://api.candide.dev/public/v3/sepolia
+PAYMASTER_URL=https://api.candide.dev/public/v3/11155111
 SPONSORSHIP_POLICY_ID= # optional
 
 PRIVATE_KEY=YOUR_PRIVATE_KEY_HERE

--- a/docs/wallet/guides/1-send-gasless-tx.mdx
+++ b/docs/wallet/guides/1-send-gasless-tx.mdx
@@ -34,7 +34,7 @@ Add the paymaster configuration to your `.env`:
 
 ```bash title=".env"
 # Paymaster service endpoint
-PAYMASTER_RPC=https://api.candide.dev/public/v3/sepolia
+PAYMASTER_RPC=https://api.candide.dev/public/v3/11155111
 
 # Optional: Your private gas policy ID (if you created one)
 SPONSORSHIP_POLICY_ID=
@@ -94,7 +94,7 @@ userOperation = paymasterUserOperation;
 
 ```bash
 # Paymaster service endpoint
-PAYMASTER_RPC=https://api.candide.dev/public/v3/sepolia
+PAYMASTER_RPC=https://api.candide.dev/public/v3/11155111
 
 # Optional: Your private gas policy ID (if you created one)
 SPONSORSHIP_POLICY_ID=
@@ -244,9 +244,9 @@ main().catch(console.error)
 
 ```bash
 CHAIN_ID=11155111
-BUNDLER_URL=https://api.candide.dev/public/v3/sepolia
+BUNDLER_URL=https://api.candide.dev/public/v3/11155111
 JSON_RPC_NODE_PROVIDER=https://ethereum-sepolia-rpc.publicnode.com
-PAYMASTER_RPC=https://api.candide.dev/public/v3/sepolia
+PAYMASTER_RPC=https://api.candide.dev/public/v3/11155111
 
 # Optional: Your private gas policy ID
 SPONSORSHIP_POLICY_ID=

--- a/docs/wallet/guides/10-getting-started-calibur.mdx
+++ b/docs/wallet/guides/10-getting-started-calibur.mdx
@@ -41,8 +41,8 @@ npm i abstractionkit dotenv
 ```bash title=".env"
 CHAIN_ID=11155111
 JSON_RPC_NODE_PROVIDER=https://ethereum-sepolia-rpc.publicnode.com
-BUNDLER_URL=https://api.candide.dev/public/v3/sepolia
-PAYMASTER_URL=https://api.candide.dev/public/v3/sepolia
+BUNDLER_URL=https://api.candide.dev/public/v3/11155111
+PAYMASTER_URL=https://api.candide.dev/public/v3/11155111
 PRIVATE_KEY=your_eoa_private_key_here
 ```
 

--- a/docs/wallet/guides/11-calibur-passkeys.mdx
+++ b/docs/wallet/guides/11-calibur-passkeys.mdx
@@ -39,8 +39,8 @@ npm i abstractionkit dotenv
 ```bash title=".env"
 CHAIN_ID=11155111
 JSON_RPC_NODE_PROVIDER=https://ethereum-sepolia-rpc.publicnode.com
-BUNDLER_URL=https://api.candide.dev/public/v3/sepolia
-PAYMASTER_URL=https://api.candide.dev/public/v3/sepolia
+BUNDLER_URL=https://api.candide.dev/public/v3/11155111
+PAYMASTER_URL=https://api.candide.dev/public/v3/11155111
 PRIVATE_KEY=your_eoa_private_key_here
 ```
 

--- a/docs/wallet/guides/12-calibur-key-management.mdx
+++ b/docs/wallet/guides/12-calibur-key-management.mdx
@@ -37,8 +37,8 @@ npm i abstractionkit dotenv
 ```bash title=".env"
 CHAIN_ID=11155111
 JSON_RPC_NODE_PROVIDER=https://ethereum-sepolia-rpc.publicnode.com
-BUNDLER_URL=https://api.candide.dev/public/v3/sepolia
-PAYMASTER_URL=https://api.candide.dev/public/v3/sepolia
+BUNDLER_URL=https://api.candide.dev/public/v3/11155111
+PAYMASTER_URL=https://api.candide.dev/public/v3/11155111
 PRIVATE_KEY=your_eoa_private_key_here
 ```
 

--- a/docs/wallet/guides/2-pay-gas-in-erc20.mdx
+++ b/docs/wallet/guides/2-pay-gas-in-erc20.mdx
@@ -68,7 +68,7 @@ Get ERC-20 faucet tokens (CTT or USDT) from our [dashboard faucet](https://dashb
 
 ```bash
 # Paymaster service endpoint
-PAYMASTER_RPC=https://api.candide.dev/public/v3/sepolia
+PAYMASTER_RPC=https://api.candide.dev/public/v3/11155111
 
 # Token address for gas payment (CTT on Sepolia for testing)
 TOKEN_ADDRESS=0xFa5854FBf9964330d761961F46565AB7326e5a3b
@@ -237,11 +237,11 @@ main().catch(console.error)
 
 ```bash
 CHAIN_ID=11155111
-BUNDLER_URL=https://api.candide.dev/public/v3/sepolia
+BUNDLER_URL=https://api.candide.dev/public/v3/11155111
 JSON_RPC_NODE_PROVIDER=https://ethereum-sepolia-rpc.publicnode.com
 
 # Paymaster configuration
-PAYMASTER_RPC=https://api.candide.dev/public/v3/sepolia
+PAYMASTER_RPC=https://api.candide.dev/public/v3/11155111
 TOKEN_ADDRESS=0xFa5854FBf9964330d761961F46565AB7326e5a3b
 
 # Your EOA credentials

--- a/docs/wallet/guides/3-multisig.mdx
+++ b/docs/wallet/guides/3-multisig.mdx
@@ -53,7 +53,7 @@ Make sure to fund your multisig account with ETH before sending transactions, or
 
 ```bash
 CHAIN_ID=11155111
-BUNDLER_URL=https://api.candide.dev/public/v3/sepolia
+BUNDLER_URL=https://api.candide.dev/public/v3/11155111
 JSON_RPC_NODE_PROVIDER=https://ethereum-sepolia-rpc.publicnode.com
 
 # Multisig owners
@@ -230,7 +230,7 @@ main().catch(console.error)
 
 ```bash
 CHAIN_ID=11155111
-BUNDLER_URL=https://api.candide.dev/public/v3/sepolia
+BUNDLER_URL=https://api.candide.dev/public/v3/11155111
 JSON_RPC_NODE_PROVIDER=https://ethereum-sepolia-rpc.publicnode.com
 
 # Multisig owners

--- a/docs/wallet/guides/6-getting-started-eip-7702.mdx
+++ b/docs/wallet/guides/6-getting-started-eip-7702.mdx
@@ -48,8 +48,8 @@ npm i abstractionkit dotenv ethers
 ```bash title=".env"
 CHAIN_ID=11155111
 JSON_RPC_NODE_PROVIDER=https://ethereum-sepolia-rpc.publicnode.com
-BUNDLER_URL=https://api.candide.dev/public/v3/sepolia
-PAYMASTER_URL=https://api.candide.dev/public/v3/sepolia
+BUNDLER_URL=https://api.candide.dev/public/v3/11155111
+PAYMASTER_URL=https://api.candide.dev/public/v3/11155111
 ```
 
 4. Create an empty file and a function to run your script

--- a/docs/wallet/guides/7-send-gasless-eip-7702.mdx
+++ b/docs/wallet/guides/7-send-gasless-eip-7702.mdx
@@ -77,7 +77,7 @@ userOperation = paymasterUserOperation;
 <TabItem value=".env" label=".env">
 
 ```env
-PAYMASTER_RPC=https://api.candide.dev/public/v3/sepolia
+PAYMASTER_RPC=https://api.candide.dev/public/v3/11155111
 SPONSORSHIP_POLICY_ID=
 ```
 

--- a/docs/wallet/guides/8-pay-gas-in-erc20-eip-7702.mdx
+++ b/docs/wallet/guides/8-pay-gas-in-erc20-eip-7702.mdx
@@ -58,7 +58,7 @@ if (tokenSelected) {
 <TabItem value=".env" label=".env">
 
 ```env
-PAYMASTER_RPC=https://api.candide.dev/public/v3/sepolia
+PAYMASTER_RPC=https://api.candide.dev/public/v3/11155111
 TOKEN_ADDRESS=0xFa5854FBf9964330d761961F46565AB7326e5a3b # CTT address on sepolia
 ```
 

--- a/docs/wallet/guides/chain-abstraction-getting-started.md
+++ b/docs/wallet/guides/chain-abstraction-getting-started.md
@@ -70,9 +70,9 @@ Create a `.env` file in your project root:
 ```bash title=".env"
 # Chain 1 (Sepolia)
 CHAIN_ID1=11155111
-BUNDLER_URL1=https://api.candide.dev/public/v3/sepolia
+BUNDLER_URL1=https://api.candide.dev/public/v3/11155111
 NODE_URL1=https://ethereum-sepolia-rpc.publicnode.com
-PAYMASTER_URL1=https://api.candide.dev/public/v3/sepolia
+PAYMASTER_URL1=https://api.candide.dev/public/v3/11155111
 
 # Chain 2 (Optimism Sepolia)
 CHAIN_ID2=11155420

--- a/docs/wallet/guides/chain-abstraction-getting-started.md
+++ b/docs/wallet/guides/chain-abstraction-getting-started.md
@@ -76,9 +76,9 @@ PAYMASTER_URL1=https://api.candide.dev/public/v3/11155111
 
 # Chain 2 (Optimism Sepolia)
 CHAIN_ID2=11155420
-BUNDLER_URL2=https://api.candide.dev/public/v3/optimism-sepolia
+BUNDLER_URL2=https://api.candide.dev/public/v3/11155420
 NODE_URL2=https://sepolia.optimism.io
-PAYMASTER_URL2=https://api.candide.dev/public/v3/optimism-sepolia
+PAYMASTER_URL2=https://api.candide.dev/public/v3/11155420
 
 # Your keys (auto-generated if not provided)
 PRIVATE_KEY=

--- a/docs/wallet/guides/recovery-with-google-using-lit.mdx
+++ b/docs/wallet/guides/recovery-with-google-using-lit.mdx
@@ -42,7 +42,7 @@ Configure the values you created from Lit dashboard in an .env file
 LIT_API_KEY=Request Relay Server API Key from Lit at https://forms.gle/RNZYtGYTY9BcD9MEA
 
 // Candide
-BUNDLER_URL="https://api.candide.dev/public/v3/sepolia" // Other networks are found here: https://docs.candide.dev/wallet/bundler/rpc-endpoints
+BUNDLER_URL="https://api.candide.dev/public/v3/11155111" // Other networks are found here: https://docs.candide.dev/wallet/bundler/rpc-endpoints
 PAYMASTER_URL="Request an API key from Candide on Discord"
     
 // Generate a Public/Private Key

--- a/docs/wallet/plugins/3-how-to-add-a-guardian.mdx
+++ b/docs/wallet/plugins/3-how-to-add-a-guardian.mdx
@@ -98,7 +98,7 @@ let userOperation = await smartAccount.createUserOperation(
 
 ```bash
 CHAIN_ID=11155111
-BUNDLER_URL=https://api.candide.dev/public/v3/sepolia
+BUNDLER_URL=https://api.candide.dev/public/v3/11155111
 NODE_URL=https://ethereum-sepolia-rpc.publicnode.com
 
 OWNER_PUBLIC_KEY=0x..
@@ -221,7 +221,7 @@ main().catch(console.error)
 
 ```bash
 CHAIN_ID=11155111
-BUNDLER_URL=https://api.candide.dev/public/v3/sepolia
+BUNDLER_URL=https://api.candide.dev/public/v3/11155111
 NODE_URL=https://ethereum-sepolia-rpc.publicnode.com
 
 # Your Smart Account credentials

--- a/docs/wallet/plugins/4-recovery-flow-guide.mdx
+++ b/docs/wallet/plugins/4-recovery-flow-guide.mdx
@@ -55,7 +55,7 @@ yarn add abstractionkit safe-recovery-service-sdk
 
 ```bash title=".env"
 CHAIN_ID=11155111
-BUNDLER_URL=https://api.candide.dev/public/v3/sepolia
+BUNDLER_URL=https://api.candide.dev/public/v3/11155111
 NODE_URL=https://ethereum-sepolia-rpc.publicnode.com
 RECOVERY_SERVICE_URL= #optional
 


### PR DESCRIPTION
## Summary
- document AbstractionKit v0.3.8 changes across SDK reference pages
- add Transport and JsonRpcNode guidance and migration notes for removed node helpers
- update SDK source links to v0.3.8 with verified line anchors

## Verification
- yarn build
- verified 95 AbstractionKit source links have in-range v0.3.8 line anchors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Docs now state the tracked SDK version (v0.3.8)
  * Bundler can be constructed with either an RPC URL or a custom transport option
  * Expanded signer compatibility: typed-data-only signers supported alongside raw-hash signers
  * EIP‑712 helper renamed and consolidated as a static helper; separate digest helper noted
  * Examples and .env snippets updated to chain-specific Candide endpoints (11155111)
  * Utilities docs restructured with a JsonRpcNode abstraction and deprecation guidance for older helpers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/developer-docs/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->