### PR TITLE
Default docs to EntryPoint v0.9 examples

### DIFF
--- a/blog/2026-02-26-entrypoint-v09-support/index.md
+++ b/blog/2026-02-26-entrypoint-v09-support/index.md
@@ -73,7 +73,7 @@ let userOperation = await smartAccount.createUserOperation(
 );
 ```
 
-View the [Simple7702AccountV09 SDK Reference](/wallet/abstractionkit/simple-7702-account-v09/) and a complete [working example on GitHub](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/04-upgrade-eoa-ep-v09.ts).
+View the [Simple7702AccountV09 SDK Reference](/wallet/abstractionkit/simple-7702-account-v09/) and a complete [working example on GitHub](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/01-upgrade-eoa.ts).
 
 ## Paymaster Support
 

--- a/docs/account-abstraction/7702/2-delegation.md
+++ b/docs/account-abstraction/7702/2-delegation.md
@@ -104,7 +104,7 @@ if (userOperation.eip7702Auth) {
 }
 ```
 
-See the [full external signer example](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/02-upgrade-eoa-external-signer.ts) on GitHub.
+See the [full external signer example](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/05-external-signer.ts) on GitHub.
 
 ## Revoke Delegation
 
@@ -130,7 +130,7 @@ if (isDelegated) {
 }
 ```
 
-See the [full revoke delegation example](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/05-revoke-delegation.ts) on GitHub.
+See the [full revoke delegation example](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/04-revoke-delegation.ts) on GitHub.
 
 ---
 

--- a/docs/wallet/abstractionkit/0-introduction.mdx
+++ b/docs/wallet/abstractionkit/0-introduction.mdx
@@ -9,15 +9,27 @@ keywords: [typescript, sdk, userOperation, library]
 
 ![image](/img/posters/abstractionkit-poster.png)
 
-A TypeScript library for building and sending ERC-4337 UserOperations with first-class support for Safe Accounts, Calibur Accounts, and Simple EIP-7702 Accounts.
+A TypeScript library for building and sending ERC-4337 UserOperations with first-class support for Safe Accounts, Calibur Accounts, and Simple EIP-7702 Accounts. New Safe examples default to `SafeMultiChainSigAccountV1` on EntryPoint v0.9, and new EIP-7702 Simple Account examples default to `Simple7702AccountV09`.
 
 AbstractionKit abstracts the complexities of the ERC-4337 standard while providing developers with maximum flexibility to build Smart Wallets.
-Use Safe Accounts, construct callData, estimate and sponsor gas (fully or with ERC-20 tokens), and send UserOperations to Bundlers – all with full type safety.
+Use Safe Accounts, construct callData, estimate and sponsor gas (fully or with ERC-20 tokens), and send UserOperations to Bundlers - all with full type safety.
 
 - AbstractionKit is agnostic of:
   - Ethereum interface libraries: ethers, web3.js, viem/wagmi
   - Bundler implementation: Plug and play from any bundler provider
   - Paymaster services: use any 3rd party paymaster, or build your own
+
+## Current Defaults
+
+| Integration | Recommended class | EntryPoint | Notes |
+|---|---|---|---|
+| Safe account, single-chain or multichain | `SafeMultiChainSigAccountV1` | v0.9 | Same class works for normal single-chain Safe UserOperations and Safe Unified Account multichain signing. |
+| Legacy Safe v0.7 compatibility | `SafeAccountV0_3_0` | v0.7 | Use when you need the older Safe 4337 module v0.3.0. |
+| Legacy Safe v0.6 compatibility | `SafeAccountV0_2_0` | v0.6 | Use only for older Safe 4337 module v0.2.0 integrations or migration paths. |
+| EIP-7702 Simple Account | `Simple7702AccountV09` | v0.9 | Recommended for new EOA delegation flows. |
+| EIP-7702 Simple Account v0.8 | `Simple7702Account` | v0.8 | Use for legacy integrations and v0.8 to v0.9 migration flows. |
+| Standard sponsorship or ERC-20 token gas | `Erc7677Paymaster` | v0.6-v0.9 | Recommended for new one-shot sponsorship and token-gas integrations. It auto-detects providers such as Candide and Pimlico and handles provider-specific metadata, supported token data, exchange rates, and paymaster addresses internally. |
+| Candide paymaster flows | `CandidePaymaster` | v0.6-v0.9 | Candide-specific client. It also supports one-shot sponsorship, but use it mainly when you need Candide-specific APIs or the v0.9 `commit -> sign -> finalize` flow that reduces wallet or remote-signer latency. |
 
 ## Why AbstractionKit
 

--- a/docs/wallet/abstractionkit/10-simple-7702-account-v09.mdx
+++ b/docs/wallet/abstractionkit/10-simple-7702-account-v09.mdx
@@ -53,7 +53,7 @@ The following ERCs are supported:
 - ERC-4337 v0.9
 
 :::info Full Example
-A complete working example is available on GitHub: [upgrade-eoa-ep-v09.ts](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/04-upgrade-eoa-ep-v09.ts)
+A complete working example is available on GitHub: [01-upgrade-eoa.ts](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/01-upgrade-eoa.ts)
 :::
 
 
@@ -204,7 +204,7 @@ userOperation.signature = await smartAccount.signUserOperationWithSigner(
 );
 ```
 
-See [External Signers](/wallet/abstractionkit/external-signers) for the full list of adapters and custom-signer integrations. EntryPoint v0.9 also supports parallel paymaster signing via the two-phase `signingPhase` context — see the [v0.9 external-signer example](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/06-external-signer-v09.ts).
+See [External Signers](/wallet/abstractionkit/external-signers) for the full list of adapters and custom-signer integrations. EntryPoint v0.9 also supports parallel paymaster signing via the two-phase `signingPhase` context — see the [parallel signing example](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/03-parallel-signing.ts).
 
 ### getUserOperationEip712Data
 

--- a/docs/wallet/abstractionkit/13-safe-unified-account.mdx
+++ b/docs/wallet/abstractionkit/13-safe-unified-account.mdx
@@ -25,7 +25,7 @@ import {
 
 # Safe Unified Account
 
-**SafeMultiChainSigAccountV1** enables chain abstraction for Safe Accounts. It extends the standard Safe Account with multichain signature support via Merkle trees, allowing you to sign UserOperations for multiple chains with a single signature.
+**SafeMultiChainSigAccountV1** is the recommended Safe account class for new AbstractionKit examples. It works for normal single-chain Safe transactions and enables chain abstraction for multichain Safe Accounts. It extends the standard Safe Account with multichain signature support via Merkle trees, allowing you to sign UserOperations for multiple chains with a single signature.
 
 Uses EntryPoint v0.9 and EIP-712 typed data with Merkle proofs.
 
@@ -338,6 +338,36 @@ userOp2.signature = signatures[1];
 #### Source code
 
 [formatSignaturesToUseroperationsSignatures](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeMultiChainSigAccount.ts#L863)
+
+### Manual EIP-712 signing for a single UserOperation
+
+`SafeMultiChainSigAccountV1` also validates single-chain UserOperations through its multichain signature scheme. If you drive `signTypedData` yourself instead of using `signUserOperationWithSigners`, format the raw wallet signature with `isMultiChainSignature: true`.
+
+```ts title="example.ts"
+import {
+    EIP712_SAFE_OPERATION_PRIMARY_TYPE,
+    SafeMultiChainSigAccountV1 as SafeAccount,
+} from "abstractionkit";
+
+const eip712Data = SafeAccount.getUserOperationEip712Data(
+    userOperation,
+    chainId,
+);
+
+const signature = await walletClient.signTypedData({
+    domain: eip712Data.domain,
+    types: eip712Data.types,
+    primaryType: EIP712_SAFE_OPERATION_PRIMARY_TYPE,
+    message: eip712Data.messageValue,
+});
+
+userOperation.signature = SafeAccount.formatSignaturesToUseroperationSignature(
+    [{ signer: ownerAddress, signature }],
+    { isMultiChainSignature: true },
+);
+```
+
+Full example: [`eip-712-signing.ts`](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-712-signing/eip-712-signing.ts).
 
 ### sendUserOperation
 

--- a/docs/wallet/abstractionkit/14-external-signers.mdx
+++ b/docs/wallet/abstractionkit/14-external-signers.mdx
@@ -13,7 +13,7 @@ Available since AbstractionKit v0.3.2.
 ## Quick start
 
 ```ts
-import { SafeAccountV0_3_0 as SafeAccount, fromViem } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount, fromViem } from "abstractionkit";
 import { privateKeyToAccount } from "viem/accounts";
 
 const signer = fromViem(privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`));
@@ -47,8 +47,8 @@ Each account class exposes its own signing method and accepts a different subset
 
 | Account | Method | Compatible adapters |
 |---|---|---|
-| `SafeAccountV0_2_0`, `SafeAccountV0_3_0`, `SafeAccountV1_5_0_M_0_3_0` | `signUserOperationWithSigners(userOperation, signers, chainId)` | `fromViem`, `fromViemWalletClient`, `fromEthersWallet`, `fromPrivateKey`, `fromSafeWebauthn`, custom |
 | `SafeMultiChainSigAccountV1` (single UserOperation) | `signUserOperationWithSigners(userOperation, signers, chainId)` | `fromViem`, `fromViemWalletClient`, `fromEthersWallet`, `fromPrivateKey`, `fromSafeWebauthn`, custom |
+| `SafeAccountV0_2_0`, `SafeAccountV0_3_0`, `SafeAccountV1_5_0_M_0_3_0` | `signUserOperationWithSigners(userOperation, signers, chainId)` | `fromViem`, `fromViemWalletClient`, `fromEthersWallet`, `fromPrivateKey`, `fromSafeWebauthn`, custom |
 | `SafeMultiChainSigAccountV1` (multi-op Merkle path) | `signUserOperationsWithSigners(userOperationsToSign, signers)` | `fromViem`, `fromViemWalletClient`, `fromEthersWallet`, `fromPrivateKey`, `fromSafeWebauthn`, custom |
 | `Simple7702Account`, `Simple7702AccountV09` | `signUserOperationWithSigner(userOperation, signer, chainId)` | `fromViem`, `fromViemWalletClient`, `fromEthersWallet`, `fromPrivateKey`, custom |
 | `Calibur7702Account` | `signUserOperationWithSigner(userOperation, signer, chainId)` | `fromViem`, `fromViemWalletClient`, `fromEthersWallet`, `fromPrivateKey`, custom |
@@ -74,7 +74,7 @@ Under the hood, every signer implements `signHash`, `signTypedData`, or both, an
 `fromViem` is the preferred viem adapter for scripts, backends, and any local private-key account. It supports both hash and typed-data signing.
 
 ```ts
-import { SafeAccountV0_3_0 as SafeAccount, fromViem } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount, fromViem } from "abstractionkit";
 import { privateKeyToAccount } from "viem/accounts";
 
 const localAccount = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`);
@@ -95,7 +95,7 @@ Full example: [`signer/fromViem.ts`](https://github.com/candidelabs/abstractionk
 Use `fromViemWalletClient` for browser wallets and injected JSON-RPC wallets. It exposes `signTypedData`, so it works with Safe accounts, Safe multi-chain signing, Simple7702 accounts, and Calibur.
 
 ```ts
-import { SafeAccountV0_3_0 as SafeAccount, fromViemWalletClient } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount, fromViemWalletClient } from "abstractionkit";
 import { createWalletClient, custom } from "viem";
 
 const walletClient = createWalletClient({
@@ -120,7 +120,7 @@ Full example: [`signer/fromViemWalletClient.ts`](https://github.com/candidelabs/
 `fromEthersWallet` accepts any ethers v6 `Wallet` or `HDNodeWallet`.
 
 ```ts
-import { SafeAccountV0_3_0 as SafeAccount, fromEthersWallet } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount, fromEthersWallet } from "abstractionkit";
 import { Wallet } from "ethers";
 
 const wallet = new Wallet(process.env.PRIVATE_KEY as string);
@@ -183,12 +183,12 @@ Full example: [`signer/customSigner.ts`](https://github.com/candidelabs/abstract
 `fromSafeWebauthn` is Safe-specific. It returns a contract-signature signer, sets `type: "contract"`, and handles Safe's WebAuthn signature encoding.
 
 ```ts
-import { SafeAccountV0_3_0, fromSafeWebauthn } from "abstractionkit";
+import { SafeMultiChainSigAccountV1, fromSafeWebauthn } from "abstractionkit";
 
 const signer = fromSafeWebauthn({
   publicKey: { x, y },
   isInit: userOperation.nonce === 0n,
-  accountClass: SafeAccountV0_3_0,
+  accountClass: SafeMultiChainSigAccountV1,
   getAssertion: async (challenge) => {
     return getWebauthnAssertion(challenge);
   },
@@ -229,8 +229,7 @@ Canonical source: [`src/signer/types.ts`](https://github.com/candidelabs/abstrac
 ## End-to-end examples
 
 - [Signer adapter examples](https://github.com/candidelabs/abstractionkit-examples/tree/main/signer)
-- [Simple7702 EntryPoint v0.8 external signer](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/05-external-signer.ts)
-- [Simple7702 EntryPoint v0.9 external signer](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/06-external-signer-v09.ts)
+- [Simple7702 EntryPoint v0.9 external signer](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/05-external-signer.ts)
 - [Calibur external signer](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/calibur-account/04-external-signer.ts)
 - [Safe Unified Account external signer](https://github.com/candidelabs/abstractionkit-examples/blob/main/chain-abstraction/add-owner-with-external-signer.ts)
 - [Safe passkeys example](https://github.com/candidelabs/abstractionkit-examples/blob/main/passkeys/index.ts)

--- a/docs/wallet/abstractionkit/3.paymaster.mdx
+++ b/docs/wallet/abstractionkit/3.paymaster.mdx
@@ -42,12 +42,22 @@ import {
 } from "/src/data/paymaster";
 
 # Paymaster
-The `CandidePaymaster` class interacts with Candide's ERC-4337 Paymaster API.
+AbstractionKit includes two paymaster clients. `CandidePaymaster` can sponsor one-shot UserOperations, but new integrations should prefer the standard `Erc7677Paymaster` for one-shot sponsorship and ERC-20 token gas flows. `Erc7677Paymaster` auto-detects supported providers such as Candide and Pimlico and handles provider-specific metadata, supported token data, exchange rates, and paymaster addresses internally. Use `CandidePaymaster` when you need Candide-specific APIs or the EntryPoint v0.9 two-phase `commit -> sign -> finalize` flow.
 
 **Supports:**
 - Gas sponsorship through Gas Policies
 - ERC-20 Token Sponsorship
 - Multi-EntryPoint
+
+## Which Paymaster Client to Use
+
+| Flow | Recommended client | Method |
+|---|---|---|
+| Sponsored gas, one-shot | `Erc7677Paymaster` | Recommended standard path: `createPaymasterUserOperation(..., context?)` |
+| ERC-20 token gas | `Erc7677Paymaster` | `createPaymasterUserOperation(..., { token })` |
+| Provider metadata and supported token details for Candide/Pimlico | `Erc7677Paymaster` | Handled automatically from the paymaster URL |
+| Candide-specific one-shot sponsorship | `CandidePaymaster` | Supported via `createSponsorPaymasterUserOperation(...)` |
+| Two-phase paymaster signing to reduce user waiting time | `CandidePaymaster` | `createSponsorPaymasterUserOperation(..., { signingPhase })` |
 
 ## Usage
 
@@ -579,7 +589,7 @@ const exchangeRate = await paymaster.fetchTokenPaymasterExchangeRate(erc20TokenA
 
 `Erc7677Paymaster` is a provider-agnostic [ERC-7677](https://eips.ethereum.org/EIPS/eip-7677) paymaster client. It speaks `pm_getPaymasterStubData` and `pm_getPaymasterData`, so it works with any compliant provider (Candide, Pimlico, Alchemy, or a self-hosted paymaster). Provider is auto-detected from the RPC URL; for Candide and Pimlico it also fetches exchange rates and paymaster addresses automatically for ERC-20 token flows.
 
-If you are using Candide's paymaster and want features like parallel signing phases, prefer `CandidePaymaster` above. Use `Erc7677Paymaster` when you want a single client that can switch providers without code changes.
+For new one-shot sponsorship and ERC-20 gas flows, prefer `Erc7677Paymaster`. For Candide and Pimlico URLs, it handles provider-specific metadata and token quote details behind the scenes. `CandidePaymaster` also supports one-shot sponsorship, but it is most useful when you need Candide-specific APIs or two-phase paymaster signing with `signingPhase: "commit"` and `signingPhase: "finalize"`, which lets the user sign while the paymaster prepares its signature in parallel and reduces wallet or remote-signer latency.
 
 ### Usage
 

--- a/docs/wallet/abstractionkit/6-safe-account.mdx
+++ b/docs/wallet/abstractionkit/6-safe-account.mdx
@@ -7,7 +7,7 @@ keywords: [safe-account, "4337", sdk, account-abstraction, gnosis-safe]
 import CardList from "/src/components/CardList";
 
 # Safe Account
-The `SafeAccount` uses the original Safe Singleton and adds ERC-4337 functionality using a module/fallback handler.
+The `SafeAccount` uses the original Safe Singleton and adds ERC-4337 functionality using a module/fallback handler. For new integrations, use [Safe Unified Account](/wallet/abstractionkit/safe-unified-account/) (`SafeMultiChainSigAccountV1`) on EntryPoint v0.9; use the V2/V3 classes below for legacy EntryPoint v0.6/v0.7 compatibility.
 
 - The V2 contracts, or `SafeAccountV0_2_0` in AbstractionKit, support EntryPoint v0.6.
 - The V3 contracts, or `SafeAccountV0_3_0` in AbstractionKit, support EntryPoint v0.7.
@@ -23,16 +23,22 @@ To learn more about the contracts, visit the [repository of Safe ERC-4337 Module
 
 ## Import
 
+### Recommended for EntryPoint v0.9
+
+```ts
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
+```
+
 ### V3 for EntryPoint v0.7
 
 ```ts
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit"; 
+import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
 ```
 
 ### V2 for EntryPoint v0.6
 
 ```ts
-import { SafeAccountV0_2_0 as SafeAccount } from "abstractionkit"; 
+import { SafeAccountV0_2_0 as SafeAccount } from "abstractionkit";
 ```
 
 ## How to Use
@@ -51,6 +57,11 @@ const accountAddress = smartAccount.accountAddress;
 ###
 
 export const GETTING_STARTED_ITEMS = [
+    {
+        title: "Safe Unified Account",
+        description: "Recommended Safe account for EntryPoint v0.9, single-chain and multichain",
+        route: "/wallet/abstractionkit/safe-unified-account",
+    },
     {
         title: "Safe Account V3",
         description: "Reference functions for Safe Account V3 with EntryPoint V7",

--- a/docs/wallet/abstractionkit/9-simple-7702-account.mdx
+++ b/docs/wallet/abstractionkit/9-simple-7702-account.mdx
@@ -9,8 +9,8 @@ import CardList from "/src/components/CardList";
 
 The `Simple7702Account` is a fully audited minimalist smart contract account that can be safely authorized by any EOA. It adds full support for major smart account features like batching and gas sponsorship.
 
-- `Simple7702Account` in AbstractionKit supports EntryPoint v0.8.
-- `Simple7702AccountV09` in AbstractionKit supports EntryPoint v0.9.
+- `Simple7702AccountV09` in AbstractionKit supports EntryPoint v0.9 and is recommended for new integrations.
+- `Simple7702Account` in AbstractionKit supports EntryPoint v0.8 for legacy integrations and migration flows.
 
 The following ERCs are supported:
 
@@ -32,16 +32,16 @@ For multi-key support, passkeys, or per-key hooks, see [Calibur Account](/wallet
 
 ## Import
 
-### EntryPoint v0.8
-
-```ts
-import { Simple7702Account } from "abstractionkit";
-```
-
-### EntryPoint v0.9
+### EntryPoint v0.9 recommended
 
 ```ts
 import { Simple7702AccountV09 } from "abstractionkit";
+```
+
+### EntryPoint v0.8 legacy
+
+```ts
+import { Simple7702Account } from "abstractionkit";
 ```
 
 ## How to Use
@@ -50,7 +50,7 @@ AbstractionKit classes are designed to support the same methods across both vers
 
 ```ts
 const delegatorPublicAddress = "0xBdbc5FBC9cA8C3F514D073eC3de840Ac84FC6D31"; // EOA public key
-const smartAccount = new Simple7702Account(delegatorPublicAddress);
+const smartAccount = new Simple7702AccountV09(delegatorPublicAddress);
 ```
 
 ###

--- a/docs/wallet/atelier-intro.mdx
+++ b/docs/wallet/atelier-intro.mdx
@@ -17,7 +17,7 @@ npm install abstractionkit
 ```
 
 ```typescript
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
 
 const account = SafeAccount.initializeNewAccount([ownerPublicKey]);
 console.log(account.accountAddress); // 0x… deterministic smart wallet address

--- a/docs/wallet/guides/0-getting-started.mdx
+++ b/docs/wallet/guides/0-getting-started.mdx
@@ -96,13 +96,13 @@ Smart accounts are smart contracts. Unlike regular wallets (EOAs), they can:
 - Implement custom validation logic
 - Support multiple signers or alternative signature schemes
 
-This guide uses Safe's smart account implementation, which is battle-tested and widely adopted.
+This guide uses the Safe Unified Account (`SafeMultiChainSigAccountV1`), which works for single-chain transactions and multichain flows with the same account class.
 
 #### Generate Account Address
 
 ```ts title="index.ts"
 import * as dotenv from "dotenv";
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
   
 async function main(): Promise<void> {
   // Load environment variables
@@ -157,7 +157,7 @@ Add this to your `index.ts` (after the account creation code):
 
 ```ts title="index.ts"
 import {
-  SafeAccountV0_3_0 as SafeAccount,
+  SafeMultiChainSigAccountV1 as SafeAccount,
   MetaTransaction,
   getFunctionSelector,
   createCallData,
@@ -217,24 +217,27 @@ We'll use a paymaster to sponsor the gas fees, making this transaction completel
 
 ```ts title="index.ts"
 import {
-  SafeAccountV0_3_0 as SafeAccount,
+  SafeMultiChainSigAccountV1 as SafeAccount,
   MetaTransaction,
   getFunctionSelector,
   createCallData,
   // highlight-start
-  CandidePaymaster,
+  Erc7677Paymaster,
   // highlight-end
 } from "abstractionkit";
 
 const paymasterUrl = process.env.PAYMASTER_URL as string;
-const paymaster = new CandidePaymaster(paymasterUrl);
+const paymaster = new Erc7677Paymaster(paymasterUrl);
 const sponsorshipPolicyId = process.env.SPONSORSHIP_POLICY_ID;
+const context = sponsorshipPolicyId
+  ? { sponsorshipPolicyId, policyId: sponsorshipPolicyId }
+  : {};
 
-const { userOperation: paymasterUserOperation } = await paymaster.createSponsorPaymasterUserOperation(
+const { userOperation: paymasterUserOperation } = await paymaster.createPaymasterUserOperation(
     smartAccount,
     userOperation,
     bundlerUrl,
-    sponsorshipPolicyId // sponsorshipPolicyId will have no effect if empty
+    context
   )
 
 userOperation = paymasterUserOperation;
@@ -310,7 +313,7 @@ Useroperation sent. Waiting to be included ......
 Useroperation receipt received.
 {
   userOpHash: '0x1acede61123ab7116eb29c797aeaec3c03615c37732ba66428524aebdb4b4514',
-  entryPoint: '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789',
+  entryPoint: '0x433709009B8330FDa32311DF1C2AFA402eD8D009',
   sender: '0xb8741a449d50ed0dcfe395287f85be152884c8d9',
   nonce: 0n,
   paymaster: '0x3fe285dcd76bcce4ac92d38a6f2f8e964041e020',
@@ -348,9 +351,9 @@ Below is the complete example code that you can copy directly to implement the f
 import * as dotenv from 'dotenv'
 
 import { 
-    SafeAccountV0_3_0 as SafeAccount,
+    SafeMultiChainSigAccountV1 as SafeAccount,
     MetaTransaction,
-    CandidePaymaster,
+    Erc7677Paymaster,
     getFunctionSelector,
     createCallData,
 } from "abstractionkit";
@@ -414,14 +417,17 @@ async function main(): Promise<void> {
 
     // Get paymaster data to sponsor the transaction
     const paymasterUrl = process.env.PAYMASTER_URL as string;
-    const paymaster: CandidePaymaster = new CandidePaymaster(paymasterUrl);
+    const paymaster = new Erc7677Paymaster(paymasterUrl);
     const sponsorshipPolicyId = process.env.SPONSORSHIP_POLICY_ID;
+    const context = sponsorshipPolicyId
+        ? { sponsorshipPolicyId, policyId: sponsorshipPolicyId }
+        : {};
 
-    const { userOperation: paymasterUserOperation } = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: paymasterUserOperation } = await paymaster.createPaymasterUserOperation(
         smartAccount,
         userOperation,
         bundlerUrl,
-        sponsorshipPolicyId // sponsorshipPolicyId will have no effect if empty
+        context
     )
     userOperation = paymasterUserOperation;
     

--- a/docs/wallet/guides/1-send-gasless-tx.mdx
+++ b/docs/wallet/guides/1-send-gasless-tx.mdx
@@ -50,19 +50,18 @@ Try public policies first, then fallback to private if no public policy matches
 <TabItem value="index.ts" label="index.ts">
 
 ```ts title="Public first, private fallback"
-import { CandidePaymaster } from "abstractionkit";
+import { Erc7677Paymaster } from "abstractionkit";
 
 const paymasterRPC = process.env.PAYMASTER_RPC as string;
-const paymaster = new CandidePaymaster(paymasterRPC);
+const paymaster = new Erc7677Paymaster(paymasterRPC);
 const sponsorshipPolicyId = process.env.SPONSORSHIP_POLICY_ID;
 
 let paymasterUserOperation;
-let sponsorMetadata;
 
 try {
   // First, try public gas policies
-  ({ userOperation: paymasterUserOperation, sponsorMetadata } =
-    await paymaster.createSponsorPaymasterUserOperation(
+  ({ userOperation: paymasterUserOperation } =
+    await paymaster.createPaymasterUserOperation(
       smartAccount,
       userOperation,
       bundlerUrl
@@ -71,12 +70,12 @@ try {
 } catch (error) {
   try {
     // Fallback to private gas policy
-    ({ userOperation: paymasterUserOperation, sponsorMetadata } =
-      await paymaster.createSponsorPaymasterUserOperation(
+    ({ userOperation: paymasterUserOperation } =
+      await paymaster.createPaymasterUserOperation(
         smartAccount,
         userOperation,
         bundlerUrl,
-        sponsorshipPolicyId
+        sponsorshipPolicyId ? { sponsorshipPolicyId, policyId: sponsorshipPolicyId } : {}
       ));
     console.log("Sponsored by your private gas policy!");
   } catch (finalError) {
@@ -117,9 +116,9 @@ Below is a complete example that demonstrates gas sponsorship with public and pr
 import * as dotenv from 'dotenv'
 
 import {
-    SafeAccountV0_3_0 as SafeAccount,
+    SafeMultiChainSigAccountV1 as SafeAccount,
     MetaTransaction,
-    CandidePaymaster,
+    Erc7677Paymaster,
     getFunctionSelector,
     createCallData,
 } from "abstractionkit";
@@ -169,43 +168,42 @@ async function main(): Promise<void> {
     )
 
     // Add paymaster sponsorship - try public first, fallback to private
-    const paymaster = new CandidePaymaster(paymasterRPC)
+    const paymaster = new Erc7677Paymaster(paymasterRPC)
     
     let paymasterUserOperation;
-    let sponsorMetadata;
     
     try {
         // Try public gas policies first
-        console.log("🔍 Checking for public gas policies...")
-        ({ userOperation: paymasterUserOperation, sponsorMetadata } =
-            await paymaster.createSponsorPaymasterUserOperation(
+        console.log("Checking for public gas policies...")
+        ({ userOperation: paymasterUserOperation } =
+            await paymaster.createPaymasterUserOperation(
                 smartAccount,
                 userOperation,
                 bundlerUrl
             ));
-        console.log("✅ Sponsored by public gas policy!")
+        console.log("Sponsored by public gas policy!")
         
     } catch (error) {
         try {
             // Fallback to private gas policy
-            console.log("🔍 Trying private gas policy fallback...")
-            ({ userOperation: paymasterUserOperation, sponsorMetadata } =
-                await paymaster.createSponsorPaymasterUserOperation(
+            console.log("Trying private gas policy fallback...")
+            ({ userOperation: paymasterUserOperation } =
+                await paymaster.createPaymasterUserOperation(
                     smartAccount,
                     userOperation,
                     bundlerUrl,
-                    sponsorshipPolicyId
+                    sponsorshipPolicyId ? { sponsorshipPolicyId, policyId: sponsorshipPolicyId } : {}
                 ));
-            console.log("✅ Sponsored by private gas policy!")
+            console.log("Sponsored by private gas policy!")
             
         } catch (finalError) {
-            console.log("❌ No gas sponsorship available");
+            console.log("No gas sponsorship available");
             throw finalError;
         }
     }
     
     userOperation = paymasterUserOperation;
-    console.log("💰 Transaction will be gasless for the user!")
+    console.log("Transaction will be gasless for the user!")
 
     // Sign the UserOperation
     userOperation.signature = smartAccount.signUserOperation(
@@ -220,18 +218,18 @@ async function main(): Promise<void> {
         bundlerUrl
     )
 
-    console.log("📤 Sponsored UserOperation sent. Waiting for confirmation...")
+    console.log("Sponsored UserOperation sent. Waiting for confirmation...")
     
     // Wait for transaction to be included
     let userOperationReceiptResult = await sendUserOperationResponse.included()
 
-    console.log("📋 UserOperation receipt received.")
+    console.log("UserOperation receipt received.")
     console.log(userOperationReceiptResult)
     
     if (userOperationReceiptResult.success) {
-        console.log("🎉 Gasless transaction successful! Hash:", userOperationReceiptResult.receipt.transactionHash)
+        console.log("Gasless transaction successful! Hash:", userOperationReceiptResult.receipt.transactionHash)
     } else {
-        console.log("❌ UserOperation execution failed")
+        console.log("UserOperation execution failed")
     }
 }
 

--- a/docs/wallet/guides/2-pay-gas-in-erc20.mdx
+++ b/docs/wallet/guides/2-pay-gas-in-erc20.mdx
@@ -37,25 +37,16 @@ Token paymasters enable users to pay gas fees with ERC-20 tokens instead of ETH,
 <TabItem value="index.ts" label="index.ts">
 
 ```ts title="Token paymaster implementation"
-import { CandidePaymaster } from "abstractionkit";
+import { Erc7677Paymaster } from "abstractionkit";
 
 const paymasterRPC = process.env.PAYMASTER_RPC as string;
 const tokenAddress = process.env.TOKEN_ADDRESS as string;
 
-const paymaster = new CandidePaymaster(paymasterRPC);
+const paymaster = new Erc7677Paymaster(paymasterRPC);
 
-const tokensSupported = await paymaster.fetchSupportedERC20TokensAndPaymasterMetadata();
-
-// Find your specific token
-const tokenSelected = tokensSupported.tokens.find(
-    token => token.address.toLowerCase() === tokenAddress.toLowerCase()
-);
-
-if (!tokenSelected) {
-    throw new Error("Token not supported by paymaster");
-}
-
-console.log(`Using ${tokenSelected.name} (${tokenSelected.symbol}) for gas payment`);
+// Pass any supported token address. Erc7677Paymaster fetches the quote
+// and prepends the required ERC-20 approval automatically.
+console.log(`Using ${tokenAddress} for gas payment`);
 ```
 
 :::tip Test Tokens
@@ -79,25 +70,14 @@ TOKEN_ADDRESS=0xFa5854FBf9964330d761961F46565AB7326e5a3b
 ### Step2: Get Token Paymaster Data
 
 ```ts title="Get token paymaster data"
-if (tokenSelected) {
-    const { userOperation: tokenOp, tokenQuote } = await paymaster.createTokenPaymasterUserOperation(
-        smartAccount,
-        userOperation,
-        tokenSelected.address,
-        bundlerUrl
-    );
-    userOperation = tokenOp;
-    console.log(`Max token cost: ${tokenQuote?.tokenCost} (smallest units)`);
-
-    // Calculate the cost in tokens
-    const cost = await paymaster.calculateUserOperationErc20TokenMaxGasCost(
-        userOperation,
-        tokenSelected.address
-    );
-    
-    console.log(`Gas cost: ${cost} wei in ${tokenSelected.symbol}`);
-    console.log(`Make sure your account has enough ${tokenSelected.symbol} tokens`);
-}
+const { userOperation: tokenOp, tokenQuote } = await paymaster.createPaymasterUserOperation(
+    smartAccount,
+    userOperation,
+    bundlerUrl,
+    { token: tokenAddress },
+);
+userOperation = tokenOp;
+console.log(`Max token cost: ${tokenQuote?.tokenCost} (smallest units)`);
 ```
 
 ## Complete Runnable Example
@@ -114,9 +94,9 @@ Below is a complete example that demonstrates ERC-20 token gas payments:
 import * as dotenv from 'dotenv'
 
 import {
-    SafeAccountV0_3_0 as SafeAccount,
+    SafeMultiChainSigAccountV1 as SafeAccount,
     MetaTransaction,
-    CandidePaymaster,
+    Erc7677Paymaster,
     getFunctionSelector,
     createCallData,
 } from "abstractionkit";
@@ -166,38 +146,22 @@ async function main(): Promise<void> {
     )
 
     // Set up token paymaster
-    const paymaster = new CandidePaymaster(paymasterRPC)
+    const paymaster = new Erc7677Paymaster(paymasterRPC)
     
-    // Get supported tokens and find the one we want to use
-    const tokensSupported = await paymaster.fetchSupportedERC20TokensAndPaymasterMetadata();
-    const tokenSelected = tokensSupported.tokens.find(
-        token => token.address.toLowerCase() === tokenAddress.toLowerCase()
-    );
-
-    if (!tokenSelected) {
-        throw new Error("Token not supported by paymaster");
-    }
-
-    console.log(`💰 Using ${tokenSelected.name} (${tokenSelected.symbol}) for gas payment`);
+    console.log(`Using ${tokenAddress} for gas payment`);
 
     // Create token paymaster UserOperation
-    const { userOperation: tokenOp, tokenQuote } = await paymaster.createTokenPaymasterUserOperation(
+    const { userOperation: tokenOp, tokenQuote } = await paymaster.createPaymasterUserOperation(
         smartAccount,
         userOperation,
-        tokenSelected.address,
-        bundlerUrl
+        bundlerUrl,
+        { token: tokenAddress },
     );
     userOperation = tokenOp;
     console.log(`Max token cost: ${tokenQuote?.tokenCost} (smallest units)`);
 
-    // Calculate the cost in tokens
-    const cost = await paymaster.calculateUserOperationErc20TokenMaxGasCost(
-        userOperation,
-        tokenSelected.address
-    );
-    
-    console.log(`⛽ Gas cost: ${cost} wei in ${tokenSelected.symbol}`);
-    console.log(`🔍 Make sure account has enough ${tokenSelected.symbol} tokens`);
+    console.log(`Gas cost: ${tokenQuote?.tokenCost} in token smallest units`);
+    console.log(`Make sure account has enough tokens`);
 
     // Sign the UserOperation
     userOperation.signature = smartAccount.signUserOperation(
@@ -212,19 +176,19 @@ async function main(): Promise<void> {
         bundlerUrl
     )
 
-    console.log("📤 UserOperation sent. Waiting for confirmation...")
+    console.log("UserOperation sent. Waiting for confirmation...")
     
     // Wait for transaction to be included
     let userOperationReceiptResult = await sendUserOperationResponse.included()
 
-    console.log("📋 UserOperation receipt received.")
+    console.log("UserOperation receipt received.")
     console.log(userOperationReceiptResult)
     
     if (userOperationReceiptResult.success) {
-        console.log("🎉 Transaction successful! Hash:", userOperationReceiptResult.receipt.transactionHash)
-        console.log(`💸 Gas paid with ${tokenSelected.symbol} tokens`);
+        console.log("Transaction successful! Hash:", userOperationReceiptResult.receipt.transactionHash)
+        console.log(`Gas paid with token ${tokenAddress}`);
     } else {
-        console.log("❌ UserOperation execution failed")
+        console.log("UserOperation execution failed")
     }
 }
 

--- a/docs/wallet/guides/3-multisig.mdx
+++ b/docs/wallet/guides/3-multisig.mdx
@@ -27,7 +27,7 @@ Set up a multisig account with multiple owners and signature threshold:
 <TabItem value="index.ts" label="index.ts">
 
 ```ts title="Create multisig account"
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
 
 const ownerPublicAddress1 = process.env.PUBLIC_ADDRESS1 as string;
 const ownerPublicAddress2 = process.env.PUBLIC_ADDRESS2 as string;
@@ -41,7 +41,7 @@ const smartAccount = SafeAccount.initializeNewAccount(
 console.log("Multisig Account Address:", smartAccount.accountAddress);
 ```
 
-> Learn more: [`initializeNewAccount`](/wallet/abstractionkit/safe-account-v3/#initializenewaccount)
+> Learn more: [`initializeNewAccount`](/wallet/abstractionkit/safe-unified-account/)
 
 :::tip Fund Your Account
 Make sure to fund your multisig account with ETH before sending transactions, or use a [paymaster for gas sponsorship](/wallet/guides/send-gasless-tx/).
@@ -87,7 +87,7 @@ userOperation.signature = smartAccount.signUserOperation(
 );
 ```
 
-> Learn more: [`signUserOperation`](/wallet/abstractionkit/safe-account-v3/#signuseroperation)
+> Learn more: [`signUserOperation`](/wallet/abstractionkit/safe-unified-account/)
 
 </TabItem>
 
@@ -114,7 +114,7 @@ userOperation.signature = smartAccount.signUserOperation(
 );
 ```
 
-> Learn more: [`initializeNewAccount`](/wallet/abstractionkit/safe-account-v3/#initializenewaccount) | [`signUserOperation`](/wallet/abstractionkit/safe-account-v3/#signuseroperation)
+> Learn more: [`initializeNewAccount`](/wallet/abstractionkit/safe-unified-account/) | [`signUserOperation`](/wallet/abstractionkit/safe-unified-account/)
 
 </TabItem>
 </Tabs>
@@ -133,7 +133,7 @@ Below is a complete example that demonstrates multisig account creation and sign
 import * as dotenv from 'dotenv'
 
 import {
-    SafeAccountV0_3_0 as SafeAccount,
+    SafeMultiChainSigAccountV1 as SafeAccount,
     MetaTransaction,
     getFunctionSelector,
     createCallData,
@@ -222,7 +222,7 @@ async function main(): Promise<void> {
 main().catch(console.error)
 ```
 
-> Learn more: [`initializeNewAccount`](/wallet/abstractionkit/safe-account-v3/#initializenewaccount) | [`createUserOperation`](/wallet/abstractionkit/safe-account-v3/#createuseroperation) | [`signUserOperation`](/wallet/abstractionkit/safe-account-v3/#signuseroperation) | [`sendUserOperation`](/wallet/abstractionkit/safe-account-v3/#senduseroperation)
+> Learn more: [`initializeNewAccount`](/wallet/abstractionkit/safe-unified-account/) | [`createUserOperation`](/wallet/abstractionkit/safe-unified-account/) | [`signUserOperation`](/wallet/abstractionkit/safe-unified-account/) | [`sendUserOperation`](/wallet/abstractionkit/safe-unified-account/)
 
 </TabItem>
 
@@ -254,7 +254,7 @@ After creating a multisig account, you can dynamically add, remove, or swap owne
 <TabItem value="add-owner" label="Add Owner">
 
 ```ts title="Add a new owner"
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
 
 // Add a new owner with threshold of 3 (now 3/3 multisig)
 const newOwnerAddress = "0x..."; // New owner's address
@@ -281,7 +281,7 @@ userOperation.signature = smartAccount.signUserOperation(
 );
 ```
 
-> Learn more: [`createAddOwnerWithThresholdMetaTransactions`](/wallet/abstractionkit/safe-account-v3/#createaddownerwiththresholdmetatransactions)
+> Learn more: [`createAddOwnerWithThresholdMetaTransactions`](/wallet/abstractionkit/safe-unified-account/)
 
 </TabItem>
 
@@ -312,7 +312,7 @@ userOperation.signature = smartAccount.signUserOperation(
 );
 ```
 
-> Learn more: [`createRemoveOwnerMetaTransaction`](/wallet/abstractionkit/safe-account-v3/#createremoveownermetatransaction)
+> Learn more: [`createRemoveOwnerMetaTransaction`](/wallet/abstractionkit/safe-unified-account/)
 
 </TabItem>
 
@@ -343,7 +343,7 @@ userOperation.signature = smartAccount.signUserOperation(
 );
 ```
 
-> Learn more: [`createSwapOwnerMetaTransactions`](/wallet/abstractionkit/safe-account-v3/#createswapownermetatransactions)
+> Learn more: [`createSwapOwnerMetaTransactions`](/wallet/abstractionkit/safe-unified-account/)
 
 </TabItem>
 </Tabs>

--- a/docs/wallet/guides/4-signing.mdx
+++ b/docs/wallet/guides/4-signing.mdx
@@ -15,7 +15,7 @@ Smart wallets can sign arbitrary messages similar to EOAs. Learn how to sign mes
 ```ts title="Signing"
 import * as dotenv from 'dotenv';
 
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit"; 
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
 import { Contract, JsonRpcProvider, Wallet, hashMessage} from "ethers"; // v6
 
 dotenv.config()
@@ -61,7 +61,7 @@ console.log(returnValue, "Success! You should see the magic value 0x1626ba7e");
 ```ts title="Signing a Message"
 import * as dotenv from 'dotenv';
 
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
 import { Contract, JsonRpcProvider, Wallet, hashMessage} from "ethers"; // v6
 
 dotenv.config();

--- a/docs/wallet/guides/5-authentication.mdx
+++ b/docs/wallet/guides/5-authentication.mdx
@@ -73,7 +73,7 @@ the Smart Account.EOAs exposes a JavaScript Ethereum Provider API.
 <TabItem value="ethers" label="ethers example">
 
 ```ts
-import { SafeAccountV0_3_0 as SafeAccount, EIP712_SAFE_OPERATION_V7_TYPE } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
 import { BrowserProvider } from "ethers";
 
 const provider = new BrowserProvider(window.ethereum);
@@ -87,7 +87,7 @@ const smartAccount = SafeAccount.initializeNewAccount([signerAddress]);
 <TabItem value="viem" label="viem example">
 
 ```ts
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
 import { createWalletClient, custom } from "viem";
 
 const viemWalletClient = createWalletClient({
@@ -111,7 +111,9 @@ The manual EIP-712 flow below is kept for advanced use cases where you need dire
 
 ##### Manual EIP-712 signing (advanced)
 
-Only this manual flow requires formatting the raw signature yourself. Regardless of which of the two approaches below you choose, you must wrap the resulting signature into a `userOperation`-compatible signature using [`formatEip712SignaturesToUserOperationSignature()`](../../abstractionkit/safe-account-v3/#formateip712signaturestouseroperationsignature). The External Signer API above does this automatically.
+Only this manual flow requires formatting the raw signature yourself. The External Signer API above does this automatically.
+
+For legacy `SafeAccountV0_3_0`, wrap raw signatures with [`formatEip712SignaturesToUserOperationSignature()`](../../abstractionkit/safe-account-v3/#formateip712signaturestouseroperationsignature). For the default `SafeMultiChainSigAccountV1`, use `formatSignaturesToUseroperationSignature([{ signer, signature }], { isMultiChainSignature: true })`; the Unified Account validates even a single UserOperation through its multichain signature scheme.
 
 1. **Direct Signing of the EIP-712 Hash**
 
@@ -128,7 +130,10 @@ const safeUserOpHash = SafeAccount.getUserOperationEip712Hash(userOperation, cha
 
 const signature = signer.signingKey.sign(safeUserOpHash).serialized;
 
-userOperation.signature = SafeAccount.formatEip712SignaturesToUseroperationSignature([signer.address], [signature]);
+userOperation.signature = SafeAccount.formatSignaturesToUseroperationSignature(
+  [{ signer: signer.address, signature }],
+  { isMultiChainSignature: true },
+);
 ```
 
 </TabItem>
@@ -144,9 +149,9 @@ const safeUserOpHash = SafeAccount.getUserOperationEip712Hash(
 
 const signature = await viemWalletClient.account.sign({ hash: safeUserOpHash });
 
-userOperation.signature = SafeAccount.formatEip712SignaturesToUseroperationSignature(
-  [viemWalletClient.account.address],
-  [signature]
+userOperation.signature = SafeAccount.formatSignaturesToUseroperationSignature(
+  [{ signer: viemWalletClient.account.address, signature }],
+  { isMultiChainSignature: true },
 );
 ```
 
@@ -169,9 +174,9 @@ let userOperation = ... // Use createUserOperation() to help you construct the u
 const { domain, types, messageValue } = SafeAccount.getUserOperationEip712Data(userOperation, chainId);
 
 const signature = await wallet.signTypedData(domain, types, messageValue);
-userOperation.signature = SafeAccount.formatEip712SignaturesToUseroperationSignature(
-  [signer.address], 
-  [signature]
+userOperation.signature = SafeAccount.formatSignaturesToUseroperationSignature(
+  [{ signer: signer.address, signature }],
+  { isMultiChainSignature: true },
 );
 ```
 
@@ -190,10 +195,10 @@ const signedTypedData = await viemWalletClient.signTypedData({
   primaryType: "SafeOp",
 } as any);
 
-userOperation.signature = SafeAccount.formatEip712SignaturesToUseroperationSignature(
-    [viemWalletClient.account.address],
-    [signedTypedData],
-  );
+userOperation.signature = SafeAccount.formatSignaturesToUseroperationSignature(
+  [{ signer: viemWalletClient.account.address, signature: signedTypedData }],
+  { isMultiChainSignature: true },
+);
 ```
 
 </TabItem>
@@ -206,7 +211,7 @@ Traditional wallets encrypts the private key in local storage. In this setup, th
 #### Signup Account Owner
 
 ```ts
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
 
 const ownerPublicAddress = process.env.PUBLIC_KEY;
 

--- a/docs/wallet/guides/6-getting-started-eip-7702.mdx
+++ b/docs/wallet/guides/6-getting-started-eip-7702.mdx
@@ -64,16 +64,16 @@ main();
 
 ## Step 2: Prepare Smart Account Instance
 
-Prepare the smart account instance using [Simple7702Account](/wallet/abstractionkit/simple-7702-account), a fully audited minimalist smart contract account safely authorized by any EOA. It provides full support for smart account features including batching and gas sponsorship.
+Prepare the smart account instance using [Simple7702AccountV09](/wallet/abstractionkit/simple-7702-account-v09), a fully audited minimalist smart contract account safely authorized by any EOA. It provides full support for smart account features including batching and gas sponsorship.
 
 ```ts title="index.ts"
-import { Simple7702Account } from "abstractionkit";
+import { Simple7702AccountV09 } from "abstractionkit";
 import { Wallet } from "ethers";
 
 // For demo: generate a random EOA. In production, use user's EOA/private key
 const eoaDelegator = Wallet.createRandom();
 
-const smartAccount = new Simple7702Account(eoaDelegator.address);
+const smartAccount = new Simple7702AccountV09(eoaDelegator.address);
 
 console.log("Smart account address (sender): " + smartAccount.accountAddress);
 ```
@@ -183,13 +183,13 @@ if (userOperation.eip7702Auth) {
 Optionally [sponsor gas](/wallet/guides/send-gasless-eip-7702/) for your user transaction or offer them to pay [gas in erc-20 tokens](/wallet/guides/pay-gas-in-erc20-eip-7702/).
 
 ```ts
-import { CandidePaymaster } from "abstractionkit";
+import { Erc7677Paymaster } from "abstractionkit";
 
 const paymasterUrl = process.env.PAYMASTER_URL as string;
 
-const paymaster = new CandidePaymaster(paymasterUrl)
+const paymaster = new Erc7677Paymaster(paymasterUrl)
 
-const { userOperation: paymasterUserOperation } = await paymaster.createSponsorPaymasterUserOperation(
+const { userOperation: paymasterUserOperation } = await paymaster.createPaymasterUserOperation(
     smartAccount,
     userOperation,
     bundlerUrl,
@@ -251,7 +251,7 @@ Useroperation sent. Waiting to be included ......
 Useroperation receipt received.
 {
   userOpHash: '0x89a5111d40c4ca45977a28419a08ca33e496a88e973bc995ec6a5a28da564cb5',
-  entryPoint: '0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108',
+  entryPoint: '0x433709009B8330FDa32311DF1C2AFA402eD8D009',
   sender: '0xbdbc5fbc9ca8c3f514d073ec3de840ac84fc6d31',
   nonce: 0n,
   paymaster: '0x0000000000000000000000000000000000000000',

--- a/docs/wallet/guides/7-send-gasless-eip-7702.mdx
+++ b/docs/wallet/guides/7-send-gasless-eip-7702.mdx
@@ -33,21 +33,20 @@ If you would like to see a full example, you can reference it [here](https://git
 ```ts
 import {
   // highlight-start
-  CandidePaymaster,
+  Erc7677Paymaster,
   // highlight-end
 } from "abstractionkit";
 
 const paymasterRPC = process.env.PAYMASTER_RPC as string;
-const paymaster: CandidePaymaster = new CandidePaymaster(paymasterRPC);
+const paymaster: Erc7677Paymaster = new Erc7677Paymaster(paymasterRPC);
 const sponsorshipPolicyId = process.env.SPONSORSHIP_POLICY_ID;
 
 // userOperation and bundlerUrl should be defined elsewhere in your code
 let paymasterUserOperation;
-let sponsorMetadata;
 try {
   // Sponsor gas using public gas policies
-  ({ userOperation: paymasterUserOperation, sponsorMetadata } =
-    await paymaster.createSponsorPaymasterUserOperation(
+  ({ userOperation: paymasterUserOperation } =
+    await paymaster.createPaymasterUserOperation(
       smartAccount,
       userOperation,
       bundlerUrl,
@@ -55,17 +54,16 @@ try {
 } catch (publicGasPolicyUnavailable) {
   try {
     // Sponsor gas using a private gas policy
-    ({ userOperation: paymasterUserOperation, sponsorMetadata } =
-      await paymaster.createSponsorPaymasterUserOperation(
+    ({ userOperation: paymasterUserOperation } =
+      await paymaster.createPaymasterUserOperation(
         smartAccount,
         userOperation,
         bundlerUrl,
-        sponsorshipPolicyId,
+        sponsorshipPolicyId ? { sponsorshipPolicyId, policyId: sponsorshipPolicyId } : {},
       ));
   } catch (privateGasPolicyUnavailable) {
-    // Fallback: propose to the user the option to pay gas in ERC-20 tokens
-  } catch (erc20GasPaymentUnavailable) {
-    // Last fallback: propose to the user the option to pay gas in the native token
+    // Fallback: propose ERC-20 token gas or native-token gas.
+    throw privateGasPolicyUnavailable;
   }
 }
 

--- a/docs/wallet/guides/8-pay-gas-in-erc20-eip-7702.mdx
+++ b/docs/wallet/guides/8-pay-gas-in-erc20-eip-7702.mdx
@@ -16,7 +16,7 @@ Enable users to pay gas in ERC-20 tokens using any [supported ERC-20 token](/wal
 1. Create a new app on the [dashboard](https://dashboard.candide.dev) and copy the Paymaster URL to your `.env` file
 2. Select an ERC-20 token for gas payment and add its address to the `.env` file (this example uses CTT) 
 
-If you would like to see a full example, you can reference it [here](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/03-upgrade-eoa-erc20-gas.ts).
+If you would like to see a full example, you can reference it [here](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/02-upgrade-eoa-erc20-gas.ts).
 
 <Tabs>
 <TabItem value="index.ts" label="index.ts">
@@ -25,32 +25,25 @@ If you would like to see a full example, you can reference it [here](https://git
 import {
   ...
   // highlight-start
-  CandidePaymaster,
+  Erc7677Paymaster,
   // highlight-end
 } from "abstractionkit";
 
 const paymasterRPC = process.env.PAYMASTER_RPC as string;
 const tokenAddress = process.env.TOKEN_ADDRESS as string;
 
-const paymaster = new CandidePaymaster(paymasterRPC)
+const paymaster = new Erc7677Paymaster(paymasterRPC)
 
-const tokensSupported = await paymaster.fetchSupportedERC20TokensAndPaymasterMetadata();
-const tokenSelected = tokensSupported.tokens.find(
-    token => token.address.toLowerCase() === tokenAddress.toLowerCase()
-);
-
-if (tokenSelected) {
-    const { userOperation: tokenOp, tokenQuote } = await paymaster.createTokenPaymasterUserOperation(
-        smartAccount, // = new Simple7702Account(eoaDelegator.address)
-        userOperation,
-        tokenSelected.address,
-        bundlerUrl,
-    )
-    userOperation = tokenOp;
-    const cost = tokenQuote?.tokenCost;
-    console.log("This useroperation may cost up to : " + cost + " wei in CTT token")
-    console.log("Please fund the sender account: " + userOperation.sender +" with more than "+ cost + " wei CTT token")
-}
+const { userOperation: tokenOp, tokenQuote } = await paymaster.createPaymasterUserOperation(
+    smartAccount, // = new Simple7702AccountV09(eoaDelegator.address)
+    userOperation,
+    bundlerUrl,
+    { token: tokenAddress },
+)
+userOperation = tokenOp;
+const cost = tokenQuote?.tokenCost;
+console.log("This useroperation may cost up to : " + cost + " in the token")
+console.log("Please fund the sender account: " + userOperation.sender + " with at least " + cost + " of the token")
 ```
 
 </TabItem>

--- a/docs/wallet/guides/9-simulate-transaction.mdx
+++ b/docs/wallet/guides/9-simulate-transaction.mdx
@@ -55,7 +55,7 @@ console.log("userop simulation link: ", userOpSimulationLink);
 ## Simulate Safe CallData 
 
 ```ts
-import { SafeAccountV0_3_0 as SafeAccount} from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount} from "abstractionkit";
 
 const smartAccount = SafeAccount.initializeNewAccount(
     [ownerPublicAddress],

--- a/docs/wallet/guides/magic.mdx
+++ b/docs/wallet/guides/magic.mdx
@@ -69,7 +69,7 @@ NEW_OWNER_PUBLIC_ADDRESS=
 
 ```ts
 import { 
-    SafeAccountV0_3_0 as SafeAccount, 
+    SafeMultiChainSigAccountV1 as SafeAccount,
     SocialRecoveryModule,
 } from "abstractionkit";
 import { Magic } from "magic-sdk";
@@ -102,7 +102,7 @@ let userOperation = await smartAccount.createUserOperation(
 <TabItem value="viem" label="viem">
 
 ```ts 
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
 import { Magic } from "magic-sdk";
 import { createWalletClient, custom } from "viem";
 
@@ -142,7 +142,7 @@ To use MagicSigner in your app's client, you must ensure the `window` object is 
 <TabItem value="ethers" label="ethers">
 
 ```ts
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
 
 const initiateRecoveryMetaTx = createConfirmRecoveryMetaTransaction(
     smartAccount.address, 
@@ -165,7 +165,7 @@ const sendTx1 = guardianSigner.sendTransaction({
 <TabItem value="viem" label="viem">
 
 ```ts 
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
 import { createWalletClient, http } from "viem";
 
 const initiateRecoveryMetaTx = createConfirmRecoveryMetaTransaction(

--- a/docs/wallet/guides/onchain-identifiers.mdx
+++ b/docs/wallet/guides/onchain-identifiers.mdx
@@ -13,7 +13,7 @@ Attribute active users and UserOperations to your project by tagging each userOp
 Pass `onChainIdentifierParams` when you initialize the Safe account. The SDK appends the marker to every userOp's `callData`.
 
 ```ts
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
 
 const smartAccount = SafeAccount.initializeNewAccount([ownerPublicAddress], {
   //highlight-start

--- a/docs/wallet/guides/recovery-with-google-using-lit.mdx
+++ b/docs/wallet/guides/recovery-with-google-using-lit.mdx
@@ -187,7 +187,7 @@ console.log("Created PKPEthersWallet using the PKP ✔️");
 We will integrate Lit as the guardian of the Smart Account. Not only that, we will be creating a special Smart Account that will be owned by the Lit key, allowing us to sponsor gas fees during the recovery process. No need to fund the associated Gmail account with funds to execute a recovery process.
 ### Initilize a Smart Account 
 ```ts 
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
 
 const smartAccount = SafeAccount.initializeNewAccount([ownerPublicAddress]);
 console.log("Smart Account Address:", smartAccount.accountAddress);

--- a/docs/wallet/guides/turnkey.mdx
+++ b/docs/wallet/guides/turnkey.mdx
@@ -99,7 +99,7 @@ let userOperation = await smartAccount.createUserOperation(
 <TabItem value="ethers" label="ethers">
 
 ```ts
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
 
 import { TurnkeySigner } from "@turnkey/ethers";
 import { TurnkeyClient } from "@turnkey/http";
@@ -137,7 +137,7 @@ const sendTx = guardianSigner.sendTransaction({
 <TabItem value="viem" label="viem">
 
 ```ts 
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
 import { createWalletClient, http } from "viem";
 
 import { TurnkeyClient } from "@turnkey/http";

--- a/docs/wallet/plugins/0-passkeys.mdx
+++ b/docs/wallet/plugins/0-passkeys.mdx
@@ -174,10 +174,10 @@ const restoredPubkey = stored ? pubkeyCoordinatesFromJson(stored) : undefined;
 
 ### Step 4: Initialize Smart Account
 
-Initialize the Safe Smart Account with the passkey as the signer. `SafeAccountV0_3_0` supports Entrypoint v0.7, while `SafeAccountV0_2_0` supports Entrypoint v0.6.
+Initialize the Safe Smart Account with the passkey as the signer. New integrations should use `SafeMultiChainSigAccountV1` on EntryPoint v0.9. Use `SafeAccountV0_3_0` for legacy EntryPoint v0.7 passkey accounts or `SafeAccountV0_2_0` for legacy EntryPoint v0.6 accounts.
 
 ```ts title="initAccount.ts"
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
 
 const smartAccount = SafeAccount.initializeNewAccount([webauthPublicKey])
 ```
@@ -209,7 +209,7 @@ AbstractionKit `v0.3.5` includes `fromSafeWebauthn`, an `ExternalSigner` adapter
 
 ```ts title="signUserOp.ts"
 import {
-    SafeAccountV0_3_0 as SafeAccount,
+    SafeMultiChainSigAccountV1 as SafeAccount,
     fromSafeWebauthn,
     webauthnSignatureFromAssertion,
 } from "abstractionkit";
@@ -242,7 +242,7 @@ userOperation.signature = await smartAccount.signUserOperationWithSigners(
 );
 ```
 
-Pass the same account class used to initialize the account. Use `SafeAccountV0_3_0` for standard Safe passkeys and `SafeMultiChainSigAccountV1` for Safe Unified Account passkeys. Keep passing `expectedSigners: [webauthPublicKey]` to `createUserOperation`; the bundler needs the larger WebAuthn dummy signature during gas estimation.
+Pass the same account class used to initialize the account. Use `SafeMultiChainSigAccountV1` for new Safe passkeys and `SafeAccountV0_3_0` only for legacy EntryPoint v0.7 passkey accounts. Keep passing `expectedSigners: [webauthPublicKey]` to `createUserOperation`; the bundler needs the larger WebAuthn dummy signature during gas estimation.
 
 #### Manual signing
 
@@ -358,7 +358,7 @@ To initialize a smart account with multiple signer types, provide both a WebAuth
 To add two Passkey signers, initialize and deploy the account with a single Passkey signer first, then use [`addOwnerWithThreshold`](/wallet/abstractionkit/safe-account-v3/#createaddownerwiththresholdmetatransactions) to add the second Passkey signer.
 
 ```ts title="multisigInit.ts"
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
 import { Wallet } from 'ethers'
 
 const webauthPublicKey = .. // see Step 3
@@ -449,7 +449,7 @@ Chains that support the RIP-7212 precompile for secp256r1 verification can reduc
 #### New Account
 
 ```ts title="precompileInit.ts"
-import { SafeAccountV0_3_0 as SafeAccount, DEFAULT_SECP256R1_PRECOMPILE_ADDRESS } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount, DEFAULT_SECP256R1_PRECOMPILE_ADDRESS } from "abstractionkit";
 
 let smartAccount = SafeAccount.initializeNewAccount(
     [webauthPublicKey],

--- a/docs/wallet/plugins/3-how-to-add-a-guardian.mdx
+++ b/docs/wallet/plugins/3-how-to-add-a-guardian.mdx
@@ -66,7 +66,7 @@ Set up the Social Recovery Module on a Safe account with a designated guardian i
 <TabItem value="enable-module.ts" label="enable-module.ts">
 
 ```ts title="Enable Social Recovery Module and add a guardian"
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
 
 const smartAccount = SafeAccount.initializeNewAccount([process.env.OWNER_PUBLIC_KEY]);
 
@@ -121,7 +121,7 @@ Below is a complete example that demonstrates enabling the recovery module and a
 import * as dotenv from 'dotenv'
 
 import {
-  SafeAccountV0_3_0 as SafeAccount,
+  SafeMultiChainSigAccountV1 as SafeAccount,
   SocialRecoveryModule,
 } from "abstractionkit";
 

--- a/docs/wallet/plugins/4-recovery-flow-guide.mdx
+++ b/docs/wallet/plugins/4-recovery-flow-guide.mdx
@@ -83,7 +83,7 @@ Request access to the recovery service [here](https://app.formbricks.com/s/brdzl
 
 ```ts title="initialize-services.ts"
 import {
-  SafeAccountV0_3_0 as SafeAccount,
+  SafeMultiChainSigAccountV1 as SafeAccount,
   SocialRecoveryModule,
   SocialRecoveryModuleGracePeriodSelector,
 } from "abstractionkit";

--- a/docs/wallet/plugins/5-recovery-alerts-guide.mdx
+++ b/docs/wallet/plugins/5-recovery-alerts-guide.mdx
@@ -85,7 +85,7 @@ Set up the recovery service client and account credentials.
 
 ```ts title="initialize-alert-service.ts"
 import { Alerts } from "safe-recovery-service-sdk";
-import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
 import { privateKeyToAccount } from "viem/accounts";
 import * as dotenv from 'dotenv';
 

--- a/docs/wallet/plugins/6-add-candide-guardian.mdx
+++ b/docs/wallet/plugins/6-add-candide-guardian.mdx
@@ -118,7 +118,7 @@ Sign the SIWE statement with the Smart Account owner key and submit registration
 
 ```ts
 import { 
-  SafeAccountV0_3_0, 
+  SafeMultiChainSigAccountV1 as SafeAccount,
   getSafeMessageEip712Data, 
   SAFE_MESSAGE_PRIMARY_TYPE 
 } from "abstractionkit";
@@ -140,7 +140,7 @@ const emailOwnerSignature = await ownerAccount.signTypedData({
     message: emailSafeTypedData.messageValue
 });
 
-const emailRegistrationSignature = SafeAccountV0_3_0.buildSignaturesFromSingerSignaturePairs([
+const emailRegistrationSignature = SafeAccount.buildSignaturesFromSingerSignaturePairs([
     { signer: ownerAccount.address, signature: emailOwnerSignature }
 ]);
 
@@ -157,7 +157,7 @@ const emailRegistrationChallengeId = await custodialGuardianService.createRegist
 
 ```ts
 import { 
-  SafeAccountV0_3_0, 
+  SafeMultiChainSigAccountV1 as SafeAccount,
   getSafeMessageEip712Data, 
   SAFE_MESSAGE_PRIMARY_TYPE 
 } from "abstractionkit";
@@ -179,7 +179,7 @@ const smsOwnerSignature = await ownerAccount.signTypedData({
     message: smsSafeTypedData.messageValue
 });
 
-const smsRegistrationSignature = SafeAccountV0_3_0.buildSignaturesFromSingerSignaturePairs([
+const smsRegistrationSignature = SafeAccount.buildSignaturesFromSingerSignaturePairs([
     { signer: ownerAccount.address, signature: smsOwnerSignature }
 ]);
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -560,13 +560,13 @@ const sidebars = {
           items: [
             {
               type: "doc",
-              id: "wallet/abstractionkit/simple-7702-account-v08",
-              label: "EntryPoint v0.8"
+              id: "wallet/abstractionkit/simple-7702-account-v09",
+              label: "EntryPoint v0.9"
             },
             {
               type: "doc",
-              id: "wallet/abstractionkit/simple-7702-account-v09",
-              label: "EntryPoint v0.9"
+              id: "wallet/abstractionkit/simple-7702-account-v08",
+              label: "EntryPoint v0.8"
             },
           ],
         },


### PR DESCRIPTION
## Summary

- Document the new AbstractionKit defaults from the examples migration: Safe Unified Account on EntryPoint v0.9, Simple7702 v0.9, and legacy Safe v0.7/v0.6 compatibility.
- Update getting started, sponsorship, ERC-20 gas, EIP-7702, authentication, external signer, and Safe Unified Account docs to match the current examples.
- Clarify Erc7677Paymaster vs CandidePaymaster, including Candide/Pimlico auto-handling and the two-phase paymaster signing latency optimization.
- Update renamed EIP-7702 example links and sidebar labels.

## Validation

- yarn build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated account guidance with new recommended defaults for unified Safe and EIP‑7702 v0.9 integrations.
  * Rewrote intro and how‑to content to emphasize type‑safe workflows: calldata construction, gas estimation/sponsorship, and UserOperation submission.
  * Added manual EIP‑712 signing instructions and refreshed external‑signer guidance.
  * Standardized examples and sidebar ordering to use the new unified Safe account.
  * Replaced paymaster docs with a selection overview and a recommended paymaster for one‑shot/ERC‑20 flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/developer-docs/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->