### PR TITLE
Fix ERC-4337 docs discrepancies

### DIFF
--- a/blog/2025-03-31-eip-7702-release/index.md
+++ b/blog/2025-03-31-eip-7702-release/index.md
@@ -39,7 +39,7 @@ To support EIP-7702, bundlers add a new JSON element named `eip7702Auth` contain
     "method": "eth_sendUserOperation",
     "params": [
         {
-            "eip7702auth": {
+            "eip7702Auth": {
                 "chainId": "0x4268",
                 "address": "0x6C193e88c2C6ACB0897d162E9496156BfFF73C0F", // must be a valid delegation address for simulation
                 "nonce": "0x0f",
@@ -75,7 +75,7 @@ let userOperation = await smartAccount.createUserOperation(
     bundlerUrl, // to estimate gas limits
     // highlight-start
     {
-        eip7702auth: {
+        eip7702Auth: {
             chainId, // where the account will be upgraded
         }
     }
@@ -84,10 +84,10 @@ let userOperation = await smartAccount.createUserOperation(
 
 // calculates the r, s, and the yParity
 // highlight-start
-userOperation.eip7702auth = createAndSignEip7702DelegationAuthorization(
-    BigInt(userOperation.eip7702auth.chainId),
-    userOperation.eip7702auth.address,
-    BigInt(userOperation.eip7702auth.nonce),
+userOperation.eip7702Auth = createAndSignEip7702DelegationAuthorization(
+    BigInt(userOperation.eip7702Auth.chainId),
+    userOperation.eip7702Auth.address,
+    BigInt(userOperation.eip7702Auth.nonce),
     eoaDelegatorPrivateKey
 );
 // highlight-end

--- a/blog/2026-02-26-entrypoint-v09-support/index.md
+++ b/blog/2026-02-26-entrypoint-v09-support/index.md
@@ -66,7 +66,7 @@ let userOperation = await smartAccount.createUserOperation(
     nodeUrl,
     bundlerUrl,
     {
-        eip7702auth: {
+        eip7702Auth: {
             chainId,
         }
     }

--- a/docs/wallet/bundler/2-rpc-methods.mdx
+++ b/docs/wallet/bundler/2-rpc-methods.mdx
@@ -8,7 +8,7 @@ import TabItem from "@theme/TabItem";
 
 # Bundler API
 
-The Bundler exposes the standard ERC-4337 JSON-RPC API.
+The Bundler exposes the standard ERC-4337 JSON-RPC API defined by ERC-7769.
 
 ## EntryPoint v0.9
 
@@ -48,7 +48,7 @@ EntryPoint v0.9 maintains ABI compatibility with v0.8, requiring no changes to e
         'paymasterData': None,
         'paymasterSignature': None, // new in v0.9: allows parallelizable paymaster signing
         // highlight-start
-        'eip7702auth': {
+        'eip7702Auth': {
           'chainId': '0x4268',
           'address': '0xa46cc63eBF4Bd77888AA327837d20b23A63a56B5',
           'nonce': '0x0f',
@@ -107,8 +107,7 @@ The signature field is ignored by the wallet, so that the operation will not req
   id: 1,
   method: "eth_estimateUserOperationGas",
   "params": [
-  [
-   {
+    {
       sender, // address
       nonce, // uint256
       factory, // address
@@ -126,7 +125,7 @@ The signature field is ignored by the wallet, so that the operation will not req
       paymasterSignature, // bytes (new in v0.9: parallelizable paymaster signing)
       signature // bytes
       // highlight-start
-      'eip7702auth': {
+      'eip7702Auth': {
         'chainId': '0x4268',
         'address': '0xa46cc63eBF4Bd77888AA327837d20b23A63a56B5', // must be valid delegation address for simulation
         'nonce': '0x0f',
@@ -135,7 +134,7 @@ The signature field is ignored by the wallet, so that the operation will not req
         's': '0x60ab7d22e278dc43b0b37afada54666c0bf9e0beb9f0cd0159de007d127f3406' // can pass a dummy signature during estimates
       }
     // highlight-end
-    }
+    },
     // highlight-next-line
     '0x433709009B8330FDa32311DF1C2AFA402eD8D009'
   ]
@@ -158,7 +157,7 @@ It returns estimates for a UserOperation Gas parameters for:
         callGasLimit, // uint256
         preVerificationGas, // uint256
         paymasterVerificationGasLimit, // uint256
-        verificationGas, // uint256
+        verificationGasLimit, // uint256
     },
 }
 ```
@@ -333,7 +332,7 @@ Highlighted code is relevant to wallets upgrading EOAs to Smart Accounts using E
         'paymasterPostOpGasLimit': None,
         'paymasterData': None,
         // highlight-start
-        'eip7702auth': {
+        'eip7702Auth': {
           'chainId': '0x4268',
           'address': '0x6C193e88c2C6ACB0897d162E9496156BfFF73C0F',
           'nonce': '0x0f',
@@ -407,8 +406,7 @@ The signature field is ignored by the wallet, so that the operation will not req
   id: 1,
   method: "eth_estimateUserOperationGas",
   "params": [
-  [
-   {
+    {
       sender, // address
       nonce, // uint256
       factory, // address
@@ -425,7 +423,7 @@ The signature field is ignored by the wallet, so that the operation will not req
       paymasterData, // bytes
       signature // bytes
       // highlight-start
-      'eip7702auth': {
+      'eip7702Auth': {
         'chainId': '0x4268',
         'address': '0x6C193e88c2C6ACB0897d162E9496156BfFF73C0F', // must be valid delegation address for simulation
         'nonce': '0x0f', 
@@ -434,7 +432,7 @@ The signature field is ignored by the wallet, so that the operation will not req
         's': '0x60ab7d22e278dc43b0b37afada54666c0bf9e0beb9f0cd0159de007d127f3406' // can pass a dummy signature during estimates
       }
     // highlight-end
-    }
+    },
     '0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108'
   ]
 }
@@ -456,7 +454,7 @@ It returns estimates for a UserOperation Gas parameters for:
         callGasLimit, // uint256
         preVerificationGas, // uint256
         paymasterVerificationGasLimit, // uint256
-        verificationGas, // uint256
+        verificationGasLimit, // uint256
     },
 }
 ```
@@ -770,7 +768,7 @@ It returns estimates for a UserOperation Gas parameters for:
         callGasLimit, // uint256
         preVerificationGas, // uint256
         paymasterVerificationGasLimit, // uint256
-        verificationGas, // uint256
+        verificationGasLimit, // uint256
     },
 }
 ```
@@ -1023,7 +1021,7 @@ It returns the hash of the User Operation. In case of an error, it returns the e
 ```
 
 #### Response
-It returns estimates for a UserOperation Gas parameters for `preVerificationGas`, `verificationGas`, and `callGasLimit`
+It returns estimates for a UserOperation Gas parameters for `preVerificationGas`, `verificationGasLimit`, and `callGasLimit`
 ```json
 {
     "jsonrpc": "2.0",
@@ -1031,7 +1029,7 @@ It returns estimates for a UserOperation Gas parameters for `preVerificationGas`
     "result": {
         callGasLimit
         preVerificationGas,
-        verificationGas,
+        verificationGasLimit,
     },
 }
 ```

--- a/docs/wallet/technical-reference/-32508-paymaster-balance-too-low.md
+++ b/docs/wallet/technical-reference/-32508-paymaster-balance-too-low.md
@@ -1,0 +1,13 @@
+---
+title: "Bundler Error -32508 Paymaster Balance Too Low"
+description: Transaction rejected because paymaster balance cannot cover all pending UserOperations
+keywords: ['-32508', error, bundler, paymaster, erc-4337]
+---
+
+# -32508 Paymaster Balance Too Low
+
+The transaction was rejected because the paymaster's EntryPoint deposit cannot cover all pending UserOperations that depend on it.
+
+This is distinct from a stake or unstake-delay failure. The paymaster may be valid, but its available deposit is not enough for the bundler to safely accept another sponsored UserOperation.
+
+If you control the paymaster, deposit more native tokens into the EntryPoint or wait for pending sponsored UserOperations to be included. If you are using a third-party paymaster service, retry later or contact the paymaster provider.

--- a/docs/wallet/technical-reference/3.bundler-error-codes.md
+++ b/docs/wallet/technical-reference/3.bundler-error-codes.md
@@ -24,5 +24,6 @@ Additionally, many of these errors will be accompanied by [an extra error messag
 | -32505      | Transaction rejected because paymaster (or signature aggregator) stake or unstake-delay is too low |
 | -32506      | Transaction rejected because wallet specified unsupported signature aggregator |
 | -32507      | Transaction rejected because of wallet signature check failed (or paymaster signature, if the paymaster uses its data as signature) |
+| -32508      | Transaction rejected because paymaster balance cannot cover all pending UserOperations |
 | -32521 | Transaction was reverted during the execution phase  |
 | -32602      | Invalid UserOperation struct/fields                                      |

--- a/sidebars.js
+++ b/sidebars.js
@@ -91,6 +91,11 @@ const sidebars = {
             },
             {
               type: "doc",
+              id: "wallet/technical-reference/-32508-paymaster-balance-too-low",
+              label: "-32508"
+            },
+            {
+              type: "doc",
               id: "wallet/technical-reference/-32521-transaction-reverted",
               label: "-32521"
             },

--- a/src/data/userOperation.ts
+++ b/src/data/userOperation.ts
@@ -125,7 +125,7 @@ export const userOperationParamV07 = [
     key: "paymasterVerificationGasLimit",
     type: "bigint | null",
     description:
-      "The amount of gas to allocate for the paymaster post-operation code",
+      "The amount of gas to allocate for the paymaster verification step",
   },
   {
     key: "paymasterPostOpGasLimit",


### PR DESCRIPTION
## Summary
- align Bundler API docs with ERC-7769 naming and gas-estimation fields
- add missing -32508 paymaster balance error documentation and sidebar entry
- fix EIP-7702 auth casing in docs/blog examples and paymaster verification gas wording

## Verification
- yarn build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Standardized EIP-7702 authentication field naming conventions across examples and SDK documentation
  * Corrected gas parameter field naming (`verificationGasLimit`) for consistency across EntryPoint versions
  * Added documentation for bundler error handling related to paymaster balance constraints

* **Bug Fixes**
  * Updated field descriptions for gas limit parameters to accurately reflect their functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->