### PR TITLE
AbstractionKit v0.4.0: release blog post + reference updates

### DIFF
--- a/blog/2026-06-10-abstractionkit-v0-4-0-release/index.md
+++ b/blog/2026-06-10-abstractionkit-v0-4-0-release/index.md
@@ -1,0 +1,120 @@
+---
+slug: abstractionkit-v0-4-0-release
+title: "AbstractionKit v0.4.0"
+description: ethers is gone from the runtime, shrinking the install. The SDK now runs in browsers and React Native out of the box. New Safe v0.7 to v0.9 module migration helpers, revert-reason decoding, and stable AA-code parsing. Two breaking changes to read before upgrading.
+image: "/img/posters/abstractionkit-meta.png"
+authors: [marc]
+tags: [sdk, react-native, paymaster, entrypoint-v09]
+---
+
+# AbstractionKit v0.4.0
+
+![abstractionkit_poster](/img/posters/abstractionkit-poster.png)
+
+`ethers` is no longer a runtime dependency, so the install footprint is smaller. The SDK now runs in browsers and React Native out of the box. Safe accounts get v0.7 to v0.9 module migration helpers, and error handling gets revert-reason decoding plus stable AA-code parsing. There are two breaking changes worth reading before you upgrade.
+
+<!-- truncate -->
+
+## ethers removed from the runtime
+
+AbstractionKit no longer ships `ethers` as a runtime dependency. Account, paymaster, transport, signer, and utility surfaces now use an internal `ethereUtils` module for ABI encoding and decoding, keccak and hashing, typed-data, and `BigInt`-safe helpers.
+
+Public API shapes are unchanged. This is a free win on upgrade: the install footprint shrinks and nothing in your integration needs to change.
+
+A reminder worth repeating: AbstractionKit still does not lock your app into a specific web3 library. Use viem or ethers in your own code, your own RPC, any ERC-4337 bundler, and any ERC-7677 paymaster. Removing the internal dependency does not change that.
+
+## Browser and React Native support, fixed
+
+Two code paths used to throw `ReferenceError` outside of Node. `generateOnChainIdentifier` relied on `Buffer`, and ABI `string` decoding relied on `TextDecoder`, both undefined in browsers without a polyfill and in React Native and Hermes.
+
+Both now use internal pure-JS UTF-8 helpers, so the SDK runs in browsers (Vite, webpack, esbuild) and React Native without extra setup.
+
+Two details to note:
+
+- UTF-8 decoding throws an `invalid UTF-8` error on malformed input (overlong, surrogate-range, out-of-range, or truncated sequences) rather than silently producing U+FFFD replacement characters. Do not expect replacement characters on bad input.
+- The Calibur, Safe, and Simple7702 executor-calldata decode paths now hex-encode the inner `bytes` payload instead of UTF-8-decoding it. The old behavior corrupted the selector and arguments.
+
+## Breaking changes
+
+Two changes need attention before upgrading.
+
+**1. Receipt `logs` are now structured.** `UserOperationReceipt.logs` and `UserOperationReceiptResult.logs` are a structured `Log[]` instead of a JSON-encoded string. Drop the parse and read the array directly:
+
+```ts
+// Before
+const logs = JSON.parse(receipt.logs)
+
+// After
+const logs = receipt.logs
+```
+
+**2. The IIFE / UMD (`unpkg`) browser build is removed.** `dist/index.iife.js` and the `unpkg` field in `package.json` are gone. The `<script>` / CDN build was effectively unusable on its own: it externalized its runtime deps as page globals, so loading it without first providing those globals threw `ReferenceError`. Install via npm and use a bundler. The ESM (`dist/index.mjs`) and CJS (`dist/index.cjs`) entries are unchanged.
+
+## Migrate a Safe from EntryPoint v0.7 to v0.9
+
+We [announced EntryPoint v0.9 support in February](/blog/entrypoint-v09-support). This release adds the helper that migrates an already-deployed Safe from the v0.7 module to the v0.9 `Safe4337MultiChainSignatureModule`.
+
+`createMigrateToSafeMultiChainSigAccountV1MetaTransactions` builds the `disableModule` + `enableModule` + `setFallbackHandler` batch. Both modules are stateless, so no storage clearing is required.
+
+```ts
+import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit"
+
+const smartAccount = new SafeAccount(accountAddress)
+
+const migrationBatch = await smartAccount.createMigrateToSafeMultiChainSigAccountV1MetaTransactions(
+  nodeRpcUrl,
+)
+```
+
+Unless you pass `{ skipPreflight: true }`, it first verifies on-chain that the account really is a Safe running the old module (the module is enabled **and** is the current fallback handler) on a Safe version `>= 1.4.1`. That turns a would-be cryptic on-chain `AA23` / `AA24` into a clear up-front error.
+
+New readers back this up: `SafeAccount.getFallbackHandler(nodeRpcUrl)` returns the active 4337 module, `SafeAccount.getSafeVersion(nodeRpcUrl)` reads `VERSION()`, `JsonRpcNode.getStorageAt(address, slot, blockTag?)` reads raw storage, and the `SAFE_FALLBACK_HANDLER_STORAGE_SLOT` constant is exported.
+
+## Decode revert reasons and AA codes
+
+Two additions make failed UserOperations easier to debug.
+
+`decodeUserOperationRevertReason(receipt)` reads the EntryPoint `UserOperationRevertReason` log directly from a mined receipt and returns the decoded reason (Error string, Panic code, or empty for likely out-of-gas), with no extra RPC call. It matches the receipt's `userOpHash`, so multi-op bundles return the right entry.
+
+```ts
+import { decodeUserOperationRevertReason } from "abstractionkit"
+
+const revert = decodeUserOperationRevertReason(receipt)
+```
+
+EntryPoint `AAxx` revert codes (for example `AA21`) are now parsed into `AbstractionKitError.aaCode`, so you can branch on a stable contract-defined code instead of matching message text:
+
+```ts
+try {
+  await smartAccount.sendUserOperation(userOp, bundlerUrl)
+} catch (error) {
+  if (error.aaCode === "AA21") {
+    // account did not pay the prefund
+  }
+}
+```
+
+The `UserOperationRevert` type and the `parseAaCode` helper are exported.
+
+## Also in this release
+
+- **Signer functions may return synchronously.** `SignHashFn` and `SignTypedDataFn` return types widen to `Hex | Promise<Hex>`, so a local-key signer can return a signature without wrapping it in a `Promise`. Existing async signers are unaffected.
+- **`SafeMultiChainSigAccount.estimateUserOperationGas`.** A new instance method estimates gas for a multi-chain-signature UserOperation against a bundler, matching the estimation surface already on the other account classes.
+- **Instance-level manual signing helpers.** `SafeAccount` and `SafeMultiChainSigAccount` expose instance-level manual signing helpers that match the existing static EIP-712 helper API, so apps that already hold an account instance can sign without re-deriving the static call surface.
+- **Paymaster `tokenCost` no longer rounds to zero on cheap-gas chains.** When `exchangeRate * maxGasCostWei < 10^18`, floor division collapsed `tokenCost` to `0n` and the prepended ERC-20 approval was also `0n`, causing reverts or the paymaster absorbing the full cost. The `Erc7677Paymaster` and `CandidePaymaster` cost paths and `calculateUserOperationErc20TokenMaxGasCost` now floor to a minimum of 1 token smallest-unit. Quote responses with a non-positive `exchangeRate` now throw `PAYMASTER_ERROR` instead of silently feeding a zero rate into the math.
+- **v0.6 `verificationGasLimit` multiplier fixed.** The paymaster multiplier in `calculateUserOperationMaxGasCost` was applied to the wrong factor on v0.6 UserOperations, undercounting the maximum gas cost.
+- **`createDisableModuleMetaTransaction` now paginates.** The predecessor lookup read a single `getModulesPaginated` page, so a Safe with more enabled modules than the page size could miss the target or compute the wrong linked-list predecessor. It now walks every page.
+- **Tenderly API key masked.** `callTenderlySimulateBundle` errors no longer surface the raw access key in their context payload.
+
+## Start building
+
+Upgrade with `yarn add abstractionkit@0.4.0`. Read the two breaking changes above first, then enjoy the smaller install and the out-of-the-box browser and React Native support.
+
+If you hit anything or want to talk through a design, find us on [Discord](https://discord.gg/8q2H6BEJuf).
+
+## Resources
+
+- [Examples repo](https://github.com/candidelabs/abstractionkit-examples)
+- [AbstractionKit on GitHub](https://github.com/candidelabs/abstractionkit)
+- [Full changelog (v0.3.8 to v0.4.0)](https://github.com/candidelabs/abstractionkit/compare/v0.3.8...v0.4.0)
+- [Documentation](https://docs.candide.dev/wallet/abstractionkit/introduction/)

--- a/docs/wallet/abstractionkit/12-calibur-account.mdx
+++ b/docs/wallet/abstractionkit/12-calibur-account.mdx
@@ -212,7 +212,7 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L327)
+[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L331)
 
 ### signUserOperation
 
@@ -251,7 +251,7 @@ userOperation.signature = smartAccount.signUserOperation(
 </Tabs>
 
 #### Source code
-[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L671)
+[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L675)
 
 ### signUserOperationWithSigner
 
@@ -299,7 +299,7 @@ See [External Signers](/wallet/abstractionkit/external-signers) for the full lis
 </Tabs>
 
 #### Source code
-[signUserOperationWithSigner](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L716)
+[signUserOperationWithSigner](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L719)
 
 ### formatWebAuthnSignature
 
@@ -345,7 +345,7 @@ userOperation.signature = smartAccount.formatWebAuthnSignature(
 </Tabs>
 
 #### Source code
-[formatWebAuthnSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L757)
+[formatWebAuthnSignature](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L760)
 
 ### sendUserOperation
 
@@ -386,7 +386,7 @@ console.log("Transaction receipt:", receipt);
 </Tabs>
 
 #### Source code
-[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L792)
+[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L794)
 
 ## Key Management Methods
 
@@ -422,7 +422,7 @@ console.log(key);
 </Tabs>
 
 #### Source code
-[createSecp256k1Key](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L812)
+[createSecp256k1Key](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L814)
 
 ### createWebAuthnP256Key
 
@@ -458,7 +458,7 @@ console.log("Key hash:", keyHash);
 </Tabs>
 
 #### Source code
-[createWebAuthnP256Key](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L826)
+[createWebAuthnP256Key](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L827)
 
 ### createP256Key
 
@@ -493,7 +493,7 @@ console.log("Key hash:", keyHash);
 </Tabs>
 
 #### Source code
-[createP256Key](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L840)
+[createP256Key](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L840)
 
 ### getKeyHash
 
@@ -527,7 +527,7 @@ console.log("Key hash:", keyHash);
 </Tabs>
 
 #### Source code
-[getKeyHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L855)
+[getKeyHash](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L854)
 
 ### createRegisterKeyMetaTransactions
 
@@ -573,7 +573,7 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createRegisterKeyMetaTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L904)
+[createRegisterKeyMetaTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L902)
 
 ### createRevokeKeyMetaTransaction
 
@@ -609,7 +609,7 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createRevokeKeyMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L945)
+[createRevokeKeyMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L942)
 
 ### createUpdateKeySettingsMetaTransaction
 
@@ -653,7 +653,7 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createUpdateKeySettingsMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L1134)
+[createUpdateKeySettingsMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L1130)
 
 ### packKeySettings
 
@@ -689,7 +689,7 @@ console.log("Packed settings:", packed);
 </Tabs>
 
 #### Source code
-[packKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L869)
+[packKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L867)
 
 ### unpackKeySettings
 
@@ -724,7 +724,7 @@ console.log("Hook:", settings.hook);
 </Tabs>
 
 #### Source code
-[unpackKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L882)
+[unpackKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L880)
 
 ## Read Methods
 
@@ -758,7 +758,7 @@ console.log("Key registered:", isRegistered);
 </Tabs>
 
 #### Source code
-[isKeyRegistered](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L1202)
+[isKeyRegistered](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L1196)
 
 ### getKeySettings
 
@@ -794,7 +794,7 @@ console.log("Hook:", settings.hook);
 </Tabs>
 
 #### Source code
-[getKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L1229)
+[getKeySettings](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L1222)
 
 ### getKey
 
@@ -829,7 +829,7 @@ console.log("Public key:", key.publicKey);
 </Tabs>
 
 #### Source code
-[getKey](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L1259)
+[getKey](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L1251)
 
 ### getKeys
 
@@ -865,7 +865,7 @@ for (const key of keys) {
 </Tabs>
 
 #### Source code
-[getKeys](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L1293)
+[getKeys](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L1284)
 
 ### isDelegatedToThisAccount
 
@@ -899,7 +899,7 @@ if (isDelegated) {
 </Tabs>
 
 #### Source code
-[isDelegatedToThisAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L1178)
+[isDelegatedToThisAccount](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L1172)
 
 ### getNonce
 
@@ -935,7 +935,7 @@ const parallelNonce = await smartAccount.getNonce(
 </Tabs>
 
 #### Source code
-[getNonce](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L1191)
+[getNonce](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L1185)
 
 ## Utility Methods
 
@@ -973,7 +973,7 @@ const callDataNoRevert = Calibur7702Account.createAccountCallData(transactions, 
 </Tabs>
 
 #### Source code
-[createAccountCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L297)
+[createAccountCallData](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L302)
 
 ### wrapSignature
 
@@ -1017,7 +1017,7 @@ const wrappedWithHook = Calibur7702Account.wrapSignature(
 </Tabs>
 
 #### Source code
-[wrapSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L166)
+[wrapSignature](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L172)
 
 ### createDummyWebAuthnSignature
 
@@ -1055,7 +1055,7 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createDummyWebAuthnSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L126)
+[createDummyWebAuthnSignature](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L133)
 
 ### getUserOperationHash
 
@@ -1087,7 +1087,7 @@ console.log("UserOperation hash:", userOpHash);
 </Tabs>
 
 #### Source code
-[getUserOperationHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L231)
+[getUserOperationHash](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L236)
 
 ### prependTokenPaymasterApproveToCallData
 
@@ -1120,7 +1120,7 @@ userOperation.callData = callDataWithApproval;
 </Tabs>
 
 #### Source code
-[prependTokenPaymasterApproveToCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L1380)
+[prependTokenPaymasterApproveToCallData](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L1370)
 
 ### createInvalidateNonceMetaTransaction
 
@@ -1155,4 +1155,4 @@ const userOperation = await smartAccount.createUserOperation(
 </Tabs>
 
 #### Source code
-[createInvalidateNonceMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Calibur/Calibur7702Account.ts#L1160)
+[createInvalidateNonceMetaTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Calibur/Calibur7702Account.ts#L1155)

--- a/docs/wallet/abstractionkit/13-safe-unified-account.mdx
+++ b/docs/wallet/abstractionkit/13-safe-unified-account.mdx
@@ -21,6 +21,8 @@ import {
   getMultiChainEip712DataReturn,
   formatSignaturesToUseroperationsSignaturesParam,
   formatSignaturesToUseroperationsSignaturesReturn,
+  estimateUserOperationGasParamMultiChainSig,
+  estimateUserOperationGasReturnMultiChainSig,
 } from "../../../src/data/accountParamAndReturnData";
 
 # Safe Unified Account
@@ -87,7 +89,7 @@ console.log("Account address (sender): " + smartAccount.accountAddress);
 
 #### Source code
 
-[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeMultiChainSigAccount.ts#L150)
+[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeMultiChainSigAccount.ts#L155)
 
 ### createUserOperation
 
@@ -129,7 +131,35 @@ const userOperation = await smartAccount.createUserOperation(
 
 #### Source code
 
-[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeMultiChainSigAccount.ts#L380)
+[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeMultiChainSigAccount.ts#L385)
+
+### estimateUserOperationGas
+
+Estimates gas limits for a multichain-signature UserOperation against a bundler, matching the estimation surface available on the other account classes. Returns a tuple of `[preVerificationGas, verificationGasLimit, callGasLimit]`.
+
+#### Usage
+
+```ts
+import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
+
+const bundlerRpc = "https://api.candide.dev/public/v3/11155111";
+
+const [preVerificationGas, verificationGasLimit, callGasLimit] =
+  await smartAccount.estimateUserOperationGas(userOperation, bundlerRpc);
+```
+
+<Tabs>
+<TabItem value="Param type" label="Param Types">
+  <DataTable items={estimateUserOperationGasParamMultiChainSig} />
+</TabItem>
+<TabItem value="Return type" label="Return Types">
+  <DataTable items={estimateUserOperationGasReturnMultiChainSig} />
+</TabItem>
+</Tabs>
+
+#### Source code
+
+[estimateUserOperationGas](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeMultiChainSigAccount.ts#L461)
 
 ### signUserOperations
 
@@ -182,7 +212,7 @@ userOp2.signature = signatures[1];
 
 #### Source code
 
-[signUserOperations](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeMultiChainSigAccount.ts#L541)
+[signUserOperations](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeMultiChainSigAccount.ts#L672)
 
 ### signUserOperationsWithSigners
 
@@ -244,7 +274,7 @@ const hash = SafeAccount.getMultiChainSingleSignatureUserOperationsEip712Hash([
 
 #### Source code
 
-[getMultiChainSingleSignatureUserOperationsEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeMultiChainSigAccount.ts#L772)
+[getMultiChainSingleSignatureUserOperationsEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeMultiChainSigAccount.ts#L902)
 
 ### getMultiChainSingleSignatureUserOperationsEip712Data
 
@@ -283,7 +313,7 @@ const signature = await wallet.signTypedData(domain, types, messageValue);
 
 #### Source code
 
-[getMultiChainSingleSignatureUserOperationsEip712Data](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeMultiChainSigAccount.ts#L806)
+[getMultiChainSingleSignatureUserOperationsEip712Data](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeMultiChainSigAccount.ts#L936)
 
 ### formatSignaturesToUseroperationsSignatures
 
@@ -337,7 +367,7 @@ userOp2.signature = signatures[1];
 
 #### Source code
 
-[formatSignaturesToUseroperationsSignatures](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeMultiChainSigAccount.ts#L863)
+[formatSignaturesToUseroperationsSignatures](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeMultiChainSigAccount.ts#L1015)
 
 ### Manual EIP-712 signing for a single UserOperation
 

--- a/docs/wallet/abstractionkit/13-safe-unified-account.mdx
+++ b/docs/wallet/abstractionkit/13-safe-unified-account.mdx
@@ -140,9 +140,27 @@ Estimates gas limits for a multichain-signature UserOperation against a bundler,
 #### Usage
 
 ```ts
-import { SafeMultiChainSigAccountV1 as SafeAccount } from "abstractionkit";
+import {
+  SafeMultiChainSigAccountV1 as SafeAccount,
+  MetaTransaction,
+} from "abstractionkit";
 
 const bundlerRpc = "https://api.candide.dev/public/v3/11155111";
+const nodeRpcUrl = "https://rpc-node-url";
+
+const smartAccount = SafeAccount.initializeNewAccount([ownerPublicAddress]);
+
+const transaction: MetaTransaction = {
+  to: "0xTargetAddress",
+  value: 0n,
+  data: "0x",
+};
+
+const userOperation = await smartAccount.createUserOperation(
+  [transaction],
+  nodeRpcUrl,
+  bundlerRpc,
+);
 
 const [preVerificationGas, verificationGasLimit, callGasLimit] =
   await smartAccount.estimateUserOperationGas(userOperation, bundlerRpc);

--- a/docs/wallet/abstractionkit/14-external-signers.mdx
+++ b/docs/wallet/abstractionkit/14-external-signers.mdx
@@ -210,12 +210,12 @@ See the [Passkeys guide](/wallet/plugins/passkeys/#sign-with-fromsafewebauthn) a
 ```ts
 type ExternalSigner = { address: `0x${string}` } & (
   | {
-      signHash: (hash: `0x${string}`, context: SignContext) => Promise<`0x${string}`>;
-      signTypedData?: (data: TypedData, context: SignContext) => Promise<`0x${string}`>;
+      signHash: (hash: `0x${string}`, context: SignContext) => `0x${string}` | Promise<`0x${string}`>;
+      signTypedData?: (data: TypedData, context: SignContext) => `0x${string}` | Promise<`0x${string}`>;
     }
   | {
-      signHash?: (hash: `0x${string}`, context: SignContext) => Promise<`0x${string}`>;
-      signTypedData: (data: TypedData, context: SignContext) => Promise<`0x${string}`>;
+      signHash?: (hash: `0x${string}`, context: SignContext) => `0x${string}` | Promise<`0x${string}`>;
+      signTypedData: (data: TypedData, context: SignContext) => `0x${string}` | Promise<`0x${string}`>;
     }
 ) & {
   type?: "ecdsa" | "contract";
@@ -224,7 +224,9 @@ type ExternalSigner = { address: `0x${string}` } & (
 
 The discriminated union enforces at compile time that every signer implements at least one of `signHash` or `signTypedData`. The optional `type` field defaults to `"ecdsa"`. Safe accounts use `"contract"` for dynamic-length EIP-1271 signatures, including WebAuthn verifier contracts.
 
-Canonical source: [`src/signer/types.ts`](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/signer/types.ts#L152).
+Both `signHash` and `signTypedData` may return either a signature directly or a `Promise` of one (`Hex | Promise<Hex>`). A local-key signer can return synchronously without wrapping the result in a `Promise`; async signers (HSMs, MPC, remote APIs) work unchanged.
+
+Canonical source: [`src/signer/types.ts`](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/signer/types.ts#L157).
 
 ## End-to-end examples
 

--- a/docs/wallet/abstractionkit/3.paymaster.mdx
+++ b/docs/wallet/abstractionkit/3.paymaster.mdx
@@ -130,7 +130,7 @@ const { userOperation: sponsoredUserOperation, sponsorMetadata } =
 </Tabs>
 
 #### Source code
-[createSponsorPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/paymaster/CandidePaymaster.ts#L571)
+[createSponsorPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/paymaster/CandidePaymaster.ts#L571)
 
 ### fetchSupportedERC20TokensAndPaymasterMetadata
 
@@ -294,7 +294,7 @@ userOperation = sponsoredUserOperation;
 </details>
 
 #### Source code
-[createTokenPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/paymaster/CandidePaymaster.ts#L612)
+[createTokenPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/paymaster/CandidePaymaster.ts#L612)
 
 ### calculateUserOperationErc20TokenMaxGasCost
 
@@ -341,7 +341,7 @@ const cost = await paymaster.calculateUserOperationErc20TokenMaxGasCost(
 </details>
 
 #### Source code
-[calculateUserOperationErc20TokenMaxGasCost](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/paymaster/CandidePaymaster.ts#L711)
+[calculateUserOperationErc20TokenMaxGasCost](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/paymaster/CandidePaymaster.ts#L712)
 
 ## Advanced Methods
 
@@ -402,7 +402,7 @@ const paymasterResult = await paymaster.getPaymasterMetaData(SafeAccount.DEFAULT
 
 #### source code
 
-[getPaymasterMetaData](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/paymaster/CandidePaymaster.ts#L334)
+[getPaymasterMetaData](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/paymaster/CandidePaymaster.ts#L334)
 
 ### getSupportedEntrypoints
 
@@ -441,7 +441,7 @@ const paymasterResult = await paymaster.getSupportedEntrypoints();
 </details>
 
 #### source code
-[getSupportedEntrypoints](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/paymaster/CandidePaymaster.ts#L311)
+[getSupportedEntrypoints](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/paymaster/CandidePaymaster.ts#L311)
 
 ### isSupportedERC20Token
 
@@ -482,7 +482,7 @@ true
 </details>
 
 #### Source
-[isSupportedERC20Token](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/paymaster/CandidePaymaster.ts#L351)
+[isSupportedERC20Token](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/paymaster/CandidePaymaster.ts#L351)
 
 ### getSupportedERC20TokenData
 
@@ -531,7 +531,7 @@ const erc20TokenData = await paymaster.getSupportedERC20TokenData(erc20TokenAddr
 </details>
 
 #### Source code
-[getSupportedERC20TokenData](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/paymaster/CandidePaymaster.ts#L367)
+[getSupportedERC20TokenData](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/paymaster/CandidePaymaster.ts#L367)
 
 ### fetchTokenPaymasterExchangeRate
 
@@ -574,7 +574,7 @@ const exchangeRate = await paymaster.fetchTokenPaymasterExchangeRate(erc20TokenA
 </details>
 
 #### Source code
-[fetchTokenPaymasterExchangeRate](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/paymaster/CandidePaymaster.ts#L748)
+[fetchTokenPaymasterExchangeRate](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/paymaster/CandidePaymaster.ts#L750)
 
 ### createPaymasterUserOperation
 
@@ -583,7 +583,7 @@ const exchangeRate = await paymaster.fetchTokenPaymasterExchangeRate(erc20TokenA
 :::
 
 #### Source code
-[createPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/paymaster/CandidePaymaster.ts#L530)
+[createPaymasterUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/paymaster/CandidePaymaster.ts#L530)
 
 ## Erc7677Paymaster
 
@@ -647,4 +647,4 @@ userOperation = tokenOp2;
 ```
 
 #### Source code
-[Erc7677Paymaster](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/paymaster/Erc7677Paymaster.ts#L186)
+[Erc7677Paymaster](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/paymaster/Erc7677Paymaster.ts#L204)

--- a/docs/wallet/abstractionkit/4.utilities.mdx
+++ b/docs/wallet/abstractionkit/4.utilities.mdx
@@ -46,6 +46,12 @@ import {
   createAndSignEip7702RawTransactionReturn,
   createEip7702TransactionHashParams,
   createEip7702TransactionHashReturn,
+  getStorageAtParams,
+  getStorageAtReturn,
+  decodeUserOperationRevertReasonParams,
+  decodeUserOperationRevertReasonReturn,
+  parseAaCodeParams,
+  parseAaCodeReturn,
 } from "/src/data/utilityParams";
 
 # Utilities
@@ -81,7 +87,7 @@ const userOpHash = createUserOperationHash(
 </Tabs>
 
 #### Source code
-[createUserOperationHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils.ts#L50)
+[createUserOperationHash](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/utils.ts#L49)
 
 ### createPackedUserOperationV6
 
@@ -106,7 +112,7 @@ const packed = createPackedUserOperationV6(userOperationV6);
 </Tabs>
 
 #### Source code
-[createPackedUserOperationV6](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils.ts#L313)
+[createPackedUserOperationV6](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/utils.ts#L310)
 
 ### createPackedUserOperationV7
 
@@ -131,7 +137,7 @@ const packed = createPackedUserOperationV7(userOperationV7);
 </Tabs>
 
 #### Source code
-[createPackedUserOperationV7](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils.ts#L353)
+[createPackedUserOperationV7](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/utils.ts#L349)
 
 ### fetchAccountNonce
 
@@ -160,7 +166,7 @@ const nonce = await fetchAccountNonce(
 </Tabs>
 
 #### Source code
-[fetchAccountNonce](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils.ts#L586)
+[fetchAccountNonce](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/utils.ts#L577)
 
 ### calculateUserOperationMaxGasCost
 
@@ -185,7 +191,7 @@ const maxCost = calculateUserOperationMaxGasCost(userOperation);
 </Tabs>
 
 #### Source code
-[calculateUserOperationMaxGasCost](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils.ts#L645)
+[calculateUserOperationMaxGasCost](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/utils.ts#L636)
 
 ### JsonRpcNode
 
@@ -245,7 +251,7 @@ const code = await node.getCode("0xYourAccountAddress");
 - `request(args, options?)`
 
 #### Source code
-[JsonRpcNode](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/transport/JsonRpcNode.ts#L50)
+[JsonRpcNode](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/transport/JsonRpcNode.ts#L50)
 
 ### getBalanceOf
 
@@ -274,6 +280,36 @@ const info = await node.getEntryPointDepositInfo(
   "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
 );
 ```
+
+### getStorageAt
+
+Reads the 32-byte storage word at a given slot via `eth_getStorageAt`.
+
+<Tabs>
+<TabItem value="example.ts" label="example.ts">
+
+```ts title="example.ts"
+import { JsonRpcNode, SAFE_FALLBACK_HANDLER_STORAGE_SLOT } from "abstractionkit";
+
+const node = new JsonRpcNode("https://ethereum-sepolia-rpc.publicnode.com");
+const word = await node.getStorageAt(
+  "0xYourAccountAddress",
+  SAFE_FALLBACK_HANDLER_STORAGE_SLOT,
+);
+```
+
+</TabItem>
+<TabItem value="Param type" label="Param Types">
+  <DataTable items={getStorageAtParams} />
+</TabItem>
+<TabItem value="Return type" label="Return Types">
+  <DataTable items={getStorageAtReturn} />
+</TabItem>
+</Tabs>
+
+#### Source code
+
+[getStorageAt](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/transport/JsonRpcNode.ts#L162)
 
 ## Simulation utils
 
@@ -308,7 +344,7 @@ const { simulation, simulationShareLink } =
 </Tabs>
 
 #### Source code
-[simulateUserOperationWithTenderlyAndCreateShareLink](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utilsTenderly.ts#L82)
+[simulateUserOperationWithTenderlyAndCreateShareLink](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/utilsTenderly.ts#L82)
 
 ### simulateUserOperationCallDataWithTenderlyAndCreateShareLink
 
@@ -341,7 +377,7 @@ const { simulation, callDataSimulationShareLink } =
 </Tabs>
 
 #### Source code
-[simulateUserOperationCallDataWithTenderlyAndCreateShareLink](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utilsTenderly.ts#L376)
+[simulateUserOperationCallDataWithTenderlyAndCreateShareLink](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/utilsTenderly.ts#L377)
 
 ### simulateSenderCallDataWithTenderlyAndCreateShareLink
 
@@ -375,7 +411,7 @@ const { simulation, callDataSimulationShareLink } =
 </Tabs>
 
 #### Source code
-[simulateSenderCallDataWithTenderlyAndCreateShareLink](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utilsTenderly.ts#L596)
+[simulateSenderCallDataWithTenderlyAndCreateShareLink](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/utilsTenderly.ts#L597)
 
 ## Multicall utils
 
@@ -417,7 +453,7 @@ const callData = encodeMultiSendCallData([
 </Tabs>
 
 #### Source code
-[encodeMultiSendCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/multisend.ts#L26)
+[encodeMultiSendCallData](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/multisend.ts#L26)
 
 ### decodeMultiSendCallData
 
@@ -442,7 +478,7 @@ const decoded = decodeMultiSendCallData(encodedCallData);
 </Tabs>
 
 #### Source code
-[decodeMultiSendCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/multisend.ts#L36)
+[decodeMultiSendCallData](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/multisend.ts#L36)
 
 ## Generic Ethereum utils
 
@@ -484,7 +520,7 @@ const callData = createCallData(
 </Tabs>
 
 #### Source code
-[createCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils.ts#L474)
+[createCallData](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/utils.ts#L466)
 
 ### getFunctionSelector
 
@@ -510,7 +546,7 @@ const selector = getFunctionSelector("transfer(address,uint256)");
 </Tabs>
 
 #### Source code
-[getFunctionSelector](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils.ts#L567)
+[getFunctionSelector](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/utils.ts#L558)
 
 ### sendJsonRpcRequest
 
@@ -539,7 +575,7 @@ const result = await sendJsonRpcRequest(
 </Tabs>
 
 #### Source code
-[sendJsonRpcRequest](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils.ts#L514)
+[sendJsonRpcRequest](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/utils.ts#L505)
 
 ### sendEthCallRequest
 
@@ -556,7 +592,7 @@ const result = await node.call({
 ```
 
 #### Source code
-[JsonRpcNode.call](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/transport/JsonRpcNode.ts#L163)
+[JsonRpcNode.call](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/transport/JsonRpcNode.ts#L189)
 
 ### sendEthGetCodeRequest
 
@@ -570,7 +606,7 @@ const code = await node.getCode("0xContractAddress");
 ```
 
 #### Source code
-[JsonRpcNode.getCode](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/transport/JsonRpcNode.ts#L137)
+[JsonRpcNode.getCode](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/transport/JsonRpcNode.ts#L137)
 
 ### getDelegatedAddress
 
@@ -588,6 +624,74 @@ if (delegatee) {
   console.log("Not delegated");
 }
 ```
+
+## Error and revert decoding
+
+### decodeUserOperationRevertReason
+
+Reads the EntryPoint's `UserOperationRevertReason` log directly from a mined receipt and returns the decoded reason, with no extra RPC call. The result is matched to the receipt's `userOpHash`, so a multi-op bundle returns the right entry. The reason is an `Error` string, a `Panic` code, or empty when the inner call left no revert data (usually out-of-gas).
+
+<Tabs>
+<TabItem value="example.ts" label="example.ts">
+
+```ts title="example.ts"
+import { decodeUserOperationRevertReason } from "abstractionkit";
+
+const receipt = await response.included();
+const revert = decodeUserOperationRevertReason(receipt);
+
+if (revert.reverted) {
+  console.log(revert.errorMessage ?? revert.panicCode ?? "out of gas");
+}
+```
+
+</TabItem>
+<TabItem value="Param type" label="Param Types">
+  <DataTable items={decodeUserOperationRevertReasonParams} />
+</TabItem>
+<TabItem value="Return type" label="Return Types">
+  <DataTable items={decodeUserOperationRevertReasonReturn} />
+</TabItem>
+</Tabs>
+
+#### Source code
+
+[decodeUserOperationRevertReason](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/userOperationRevert.ts#L45)
+
+### parseAaCode
+
+Parses an EntryPoint `AAxx` revert code (e.g. `AA21`) out of an error message, so you can branch on a stable contract-defined code instead of matching message text. When a UserOperation fails, AbstractionKit also surfaces this code directly on `AbstractionKitError.aaCode`, so most callers can read `error.aaCode` without calling `parseAaCode` themselves.
+
+<Tabs>
+<TabItem value="example.ts" label="example.ts">
+
+```ts title="example.ts"
+import { parseAaCode } from "abstractionkit";
+
+try {
+  await smartAccount.sendUserOperation(userOperation, bundlerUrl);
+} catch (error) {
+  // Read the code straight off the error...
+  if (error.aaCode === "AA21") {
+    // account did not pay the prefund
+  }
+  // ...or parse it from any message string
+  const code = parseAaCode(error.message);
+}
+```
+
+</TabItem>
+<TabItem value="Param type" label="Param Types">
+  <DataTable items={parseAaCodeParams} />
+</TabItem>
+<TabItem value="Return type" label="Return Types">
+  <DataTable items={parseAaCodeReturn} />
+</TabItem>
+</Tabs>
+
+#### Source code
+
+[parseAaCode](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/errors.ts#L146)
 
 ## EIP-7702 Utilities
 
@@ -633,7 +737,7 @@ const authorization = await createAndSignEip7702DelegationAuthorization(
 </Tabs>
 
 #### Source code
-[createAndSignEip7702DelegationAuthorization](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils7702.ts#L137)
+[createAndSignEip7702DelegationAuthorization](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/utils7702.ts#L142)
 
 ### createRevokeDelegationAuthorization
 
@@ -664,7 +768,7 @@ const revokeAuth = createRevokeDelegationAuthorization(
 </Tabs>
 
 #### Source code
-[createRevokeDelegationAuthorization](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils7702.ts#L192)
+[createRevokeDelegationAuthorization](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/utils7702.ts#L197)
 
 ### createEip7702DelegationAuthorizationHash
 
@@ -693,7 +797,7 @@ const hash = createEip7702DelegationAuthorizationHash(
 </Tabs>
 
 #### Source code
-[createEip7702DelegationAuthorizationHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils7702.ts#L209)
+[createEip7702DelegationAuthorizationHash](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/utils7702.ts#L214)
 
 ### createAndSignEip7702RawTransaction
 
@@ -730,7 +834,7 @@ const rawTx = createAndSignEip7702RawTransaction(
 </Tabs>
 
 #### Source code
-[createAndSignEip7702RawTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils7702.ts#L255)
+[createAndSignEip7702RawTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/utils7702.ts#L259)
 
 ### createEip7702TransactionHash
 
@@ -766,4 +870,4 @@ const txHash = createEip7702TransactionHash(
 </Tabs>
 
 #### Source code
-[createEip7702TransactionHash](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/utils7702.ts#L319)
+[createEip7702TransactionHash](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/utils7702.ts#L323)

--- a/docs/wallet/abstractionkit/7-safe-account-v2.mdx
+++ b/docs/wallet/abstractionkit/7-safe-account-v2.mdx
@@ -116,7 +116,7 @@ const smartAccount = new SafeAccount(accountAddress);
 
 #### Source code
 
-[constructor](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L44)
+[constructor](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_2_0.ts#L43)
 
 ## Methods
 
@@ -168,7 +168,7 @@ Account address(sender) : 0x1a02592A3484c2077d2E5D24482497F85e1980C6
 
 #### Source code
 
-[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L109)
+[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_2_0.ts#L108)
 
 ### isDeployed
 
@@ -206,7 +206,7 @@ const account = (await SafeAccount.isDeployed(accountAddress, nodeRpcUrl))
 
 #### Source code
 
-[isDeployed](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccount.ts#L257)
+[isDeployed](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccount.ts#L263)
 
 ### createUserOperation
 
@@ -344,7 +344,7 @@ console.log(userOperation);
 </details>
 
 #### Source code
-[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L322)
+[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_2_0.ts#L321)
 
 ### signUserOperation
 
@@ -390,7 +390,7 @@ console.log(signature);
 </details>
 
 #### Source code
-[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L456)
+[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_2_0.ts#L438)
 
 ### signUserOperationWithSigners
 
@@ -412,7 +412,7 @@ userOperation.signature = await smartAccount.signUserOperationWithSigners(
 See [External Signers](/wallet/abstractionkit/external-signers) for the full list of adapters and custom-signer integrations.
 
 #### Source code
-[signUserOperationWithSigners](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L483)
+[signUserOperationWithSigners](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_2_0.ts#L465)
 
 ### sendUserOperation
 
@@ -488,7 +488,7 @@ receipt: {
 </details>
 
 #### Source code
-[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccount.ts#L989)
+[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccount.ts#L1078)
 
 ## Advanced Methods
 
@@ -542,7 +542,7 @@ Account address(sender) : 0x1a02592A3484c2077d2E5D24482497F85e1980C6
 
 #### Source code
 
-[createAccountAddress](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L72)
+[createAccountAddress](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_2_0.ts#L71)
 
 ### createInitCode
 
@@ -591,7 +591,7 @@ initCode: 0x...
 
 #### Source code
 
-[createInitCode](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L294)
+[createInitCode](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_2_0.ts#L293)
 
 ### createAccountAddressAndInitCode
 
@@ -643,7 +643,7 @@ initCode: 0x...
 
 #### Source code
 
-[createAccountAddressAndInitCode](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L233)
+[createAccountAddressAndInitCode](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_2_0.ts#L232)
 
 ### createInitializerCallData
 
@@ -686,7 +686,7 @@ initializeCallData: 0xb63e800d00000000000000000000000000000000000000000000000000
 </details>
 
 #### Source code
-[createInitializerCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L258)
+[createInitializerCallData](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_2_0.ts#L257)
 
 ### createAccountCallDataSingleTransaction
 
@@ -739,7 +739,7 @@ callData : 0xf34308ef000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2
 
 #### Source code
 
-[createAccountCallDataSingleTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccount.ts#L274)
+[createAccountCallDataSingleTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccount.ts#L280)
 
 ### createAccountCallDataBatchTransactions
 
@@ -804,7 +804,7 @@ callData : 0xf34308ef000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2
 
 #### Source code
 
-[createAccountCallDataBatchTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccount.ts#L309)
+[createAccountCallDataBatchTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccount.ts#L315)
 
 ### estimateUserOperationGas
 
@@ -877,7 +877,7 @@ const [preVerificationGas, verificationGasLimit, callGasLimit] = await estimateU
 </details>
 
 #### Source code
-[estimateUserOperationGas](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L425)
+[estimateUserOperationGas](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_2_0.ts#L407)
 
 ### getUserOperationEip712Hash
 
@@ -914,7 +914,7 @@ console.log(safeUserOpHash);
 
 #### Source code
 
-[getUserOperationEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L163)
+[getUserOperationEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_2_0.ts#L162)
 
 ### formatEip712SignaturesToUseroperationSignature
 
@@ -990,7 +990,7 @@ userOperation.signature = formatedSig;
 </details>
 
 #### Source code
-[formatEip712SignaturesToUseroperationSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccount.ts#L516)
+[formatEip712SignaturesToUseroperationSignature](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccount.ts#L521)
 
 ### isModuleEnabled
 
@@ -1118,7 +1118,7 @@ const userOperation = await smartAccount.createUserOperation(
 
 #### Source code
 
-[createMigrateToSafeAccountV0_3_0MetaTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_2_0.ts#L368)
+[createMigrateToSafeAccountV0_3_0MetaTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_2_0.ts#L367)
 
 ## Audits
 - [Audits by Ackee and OpenZeppelin](https://github.com/safe-global/safe-modules/blob/main/modules/4337/docs/v0.2.0/audit.md)

--- a/docs/wallet/abstractionkit/8-safe-account-v3.mdx
+++ b/docs/wallet/abstractionkit/8-safe-account-v3.mdx
@@ -1069,6 +1069,9 @@ Reads the active ERC-4337 fallback handler (the 4337 module) currently set on th
 ```ts
 import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
 
+const accountAddress = "0x1a02592A3484c2077d2E5D24482497F85e1980C6";
+const nodeRpcUrl = "https://rpc2.sepolia.org";
+
 const smartAccount = new SafeAccount(accountAddress);
 const fallbackHandler = await smartAccount.getFallbackHandler(nodeRpcUrl);
 ```
@@ -1094,6 +1097,9 @@ Reads the Safe singleton version string via `VERSION()`, for example `"1.4.1"`.
 
 ```ts
 import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+
+const accountAddress = "0x1a02592A3484c2077d2E5D24482497F85e1980C6";
+const nodeRpcUrl = "https://rpc2.sepolia.org";
 
 const smartAccount = new SafeAccount(accountAddress);
 const version = await smartAccount.getSafeVersion(nodeRpcUrl);

--- a/docs/wallet/abstractionkit/8-safe-account-v3.mdx
+++ b/docs/wallet/abstractionkit/8-safe-account-v3.mdx
@@ -1032,7 +1032,9 @@ Unless `{ skipPreflight: true }` is passed, it first verifies on-chain that the 
 ```ts
 import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
 
+const accountAddress = "0x1a02592A3484c2077d2E5D24482497F85e1980C6";
 const nodeRpcUrl = "https://rpc2.sepolia.org";
+const bundlerUrl = "https://api.candide.dev/public/v3/11155111";
 
 const smartAccount = new SafeAccount(accountAddress);
 

--- a/docs/wallet/abstractionkit/8-safe-account-v3.mdx
+++ b/docs/wallet/abstractionkit/8-safe-account-v3.mdx
@@ -52,6 +52,12 @@ import {
   verifyWebAuthnSignatureForMessageHashReturn,
   getUserOperationEip712DataV7Param,
   getUserOperationEip712DataReturn,
+  createMigrateToMultiChainSigParam,
+  createMigrateToMultiChainSigReturn,
+  getFallbackHandlerParams,
+  getFallbackHandlerReturn,
+  getSafeVersionParams,
+  getSafeVersionReturn,
 } from "../../../src/data/accountParamAndReturnData";
 import { userOperationParamV07, userOperationReceiptResultType } from "/src/data/userOperation";
 import {
@@ -135,7 +141,7 @@ Account address(sender) : 0x1a02592A3484c2077d2E5D24482497F85e1980C6
 
 #### Source code
 
-[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_3_0.ts#L96)
+[initializeNewAccount](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_3_0.ts#L97)
 
 ### isDeployed
 
@@ -173,7 +179,7 @@ const account = (await SafeAccount.isDeployed(accountAddress, nodeRpcUrl))
 
 #### Source code
 
-[isDeployed](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccount.ts#L257)
+[isDeployed](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccount.ts#L263)
 
 ### createUserOperation
 
@@ -315,7 +321,7 @@ console.log(userOperation);
 </details>
 
 #### Source code
-[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_3_0.ts#L288)
+[createUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_3_0.ts#L289)
 
 ### signUserOperation
 
@@ -363,7 +369,7 @@ console.log(signature);
 </details>
 
 #### Source code
-[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_3_0.ts#L355)
+[signUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_3_0.ts#L356)
 
 ### signUserOperationWithSigners
 
@@ -385,7 +391,7 @@ userOperation.signature = await smartAccount.signUserOperationWithSigners(
 See [External Signers](/wallet/abstractionkit/external-signers) for the full list of adapters and custom-signer integrations.
 
 #### Source code
-[signUserOperationWithSigners](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_3_0.ts#L394)
+[signUserOperationWithSigners](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_3_0.ts#L395)
 
 ### sendUserOperation
 
@@ -461,7 +467,7 @@ receipt: {
 </details>
 
 #### Source code
-[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccount.ts#L989)
+[sendUserOperation](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccount.ts#L1078)
 
 ## Advanced Methods
 
@@ -515,7 +521,7 @@ Account address(sender) : 0x1a02592A3484c2077d2E5D24482497F85e1980C6
 
 #### Source code
 
-[createAccountAddress](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_3_0.ts#L73)
+[createAccountAddress](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_3_0.ts#L74)
 
 ### createFactoryAddressAndData
 
@@ -567,7 +573,7 @@ factoryData:  0x1688f0b900000000000000000000000029fcb43b46531bca003ddc8fcb67ffe9
 
 #### Source code
 
-[createFactoryAddressAndData](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_3_0.ts#L258)
+[createFactoryAddressAndData](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_3_0.ts#L259)
 
 ### createInitializerCallData
 
@@ -610,7 +616,7 @@ initializeCallData: 0xb63e800d00000000000000000000000000000000000000000000000000
 </details>
 
 #### Source
-[createInitializerCallData](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_3_0.ts#L222)
+[createInitializerCallData](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_3_0.ts#L223)
 
 ### createAccountCallDataSingleTransaction
 
@@ -663,7 +669,7 @@ callData : 0xf34308ef000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2
 
 #### Source code
 
-[createAccountCallDataSingleTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccount.ts#L274)
+[createAccountCallDataSingleTransaction](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccount.ts#L280)
 
 ### createAccountCallDataBatchTransactions
 
@@ -728,7 +734,7 @@ callData : 0xf34308ef000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2
 
 #### Source code
 
-[createAccountCallDataBatchTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccount.ts#L309)
+[createAccountCallDataBatchTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccount.ts#L315)
 
 ### estimateUserOperationGas
 
@@ -801,7 +807,7 @@ const [preVerificationGas, verificationGasLimit, callGasLimit] = await estimateU
 </details>
 
 #### Source code
-[estimateUserOperationGas](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_3_0.ts#L324)
+[estimateUserOperationGas](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_3_0.ts#L325)
 
 ### getUserOperationEip712Hash
 
@@ -845,7 +851,7 @@ console.log(safeUserOpHash);
 </details>
 
 #### Source
-[getUserOperationEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccountV0_3_0.ts#L150)
+[getUserOperationEip712Hash](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_3_0.ts#L151)
 
 ### formatEip712SignaturesToUseroperationSignature
 
@@ -921,7 +927,7 @@ userOperation.signature = formatedSig;
 </details>
 
 #### Source code
-[formatEip712SignaturesToUseroperationSignature](https://github.com/candidelabs/abstractionkit/blob/v0.3.8/src/account/Safe/SafeAccount.ts#L516)
+[formatEip712SignaturesToUseroperationSignature](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccount.ts#L521)
 
 
 ### isModuleEnabled
@@ -1014,6 +1020,97 @@ A static method that returns the EIP-712 domain data for a userOp
   <DataTable items={getUserOperationEip712DataReturn} />
 </TabItem>
 </Tabs>
+
+### createMigrateToSafeMultiChainSigAccountV1MetaTransactions
+
+Creates an array of meta-transactions that migrate a deployed Safe from the EntryPoint v0.7 module to the EntryPoint v0.9 `Safe4337MultiChainSignatureModule`. The migration disables the v0.7 module, enables the v0.9 module, and updates the fallback handler. Both modules are stateless, so no storage clearing is required.
+
+Unless `{ skipPreflight: true }` is passed, it first verifies on-chain that the account is a Safe (version `>= 1.4.1`) running the old module, where the module is both enabled and the current fallback handler. This turns a would-be cryptic on-chain `AA23` / `AA24` into a clear up-front error.
+
+#### Usage
+
+```ts
+import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+
+const nodeRpcUrl = "https://rpc2.sepolia.org";
+
+const smartAccount = new SafeAccount(accountAddress);
+
+const migrationMetaTransactions =
+  await smartAccount.createMigrateToSafeMultiChainSigAccountV1MetaTransactions(nodeRpcUrl);
+
+// Include these meta-transactions in a UserOperation to execute the migration
+const userOperation = await smartAccount.createUserOperation(
+  migrationMetaTransactions,
+  nodeRpcUrl,
+  bundlerUrl,
+);
+```
+
+<Tabs>
+<TabItem value="Param type" label="Param Types">
+  <DataTable items={createMigrateToMultiChainSigParam} />
+</TabItem>
+<TabItem value="Return type" label="Return Types">
+  <DataTable items={createMigrateToMultiChainSigReturn} />
+</TabItem>
+</Tabs>
+
+#### Source code
+
+[createMigrateToSafeMultiChainSigAccountV1MetaTransactions](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccountV0_3_0.ts#L429)
+
+### getFallbackHandler
+
+Reads the active ERC-4337 fallback handler (the 4337 module) currently set on the Safe.
+
+#### Usage
+
+```ts
+import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+
+const smartAccount = new SafeAccount(accountAddress);
+const fallbackHandler = await smartAccount.getFallbackHandler(nodeRpcUrl);
+```
+
+<Tabs>
+<TabItem value="Param type" label="Param Types">
+  <DataTable items={getFallbackHandlerParams} />
+</TabItem>
+<TabItem value="Return type" label="Return Types">
+  <DataTable items={getFallbackHandlerReturn} />
+</TabItem>
+</Tabs>
+
+#### Source code
+
+[getFallbackHandler](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccount.ts#L2837)
+
+### getSafeVersion
+
+Reads the Safe singleton version string via `VERSION()`, for example `"1.4.1"`.
+
+#### Usage
+
+```ts
+import { SafeAccountV0_3_0 as SafeAccount } from "abstractionkit";
+
+const smartAccount = new SafeAccount(accountAddress);
+const version = await smartAccount.getSafeVersion(nodeRpcUrl);
+```
+
+<Tabs>
+<TabItem value="Param type" label="Param Types">
+  <DataTable items={getSafeVersionParams} />
+</TabItem>
+<TabItem value="Return type" label="Return Types">
+  <DataTable items={getSafeVersionReturn} />
+</TabItem>
+</Tabs>
+
+#### Source code
+
+[getSafeVersion](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccount.ts#L2853)
 
 ## Audits
 - [Audits by Ackee](https://github.com/safe-global/safe-modules/blob/main/modules/4337/docs/v0.3.0/audit.md)

--- a/docs/wallet/guides/onchain-identifiers.mdx
+++ b/docs/wallet/guides/onchain-identifiers.mdx
@@ -46,7 +46,7 @@ const onchainIdentifier = smartAccount.onChainIdentifier;
 // "0x5afe00..."
 ```
 
-View the identifier generation in the [generateOnChainIdentifier](https://github.com/candidelabs/abstractionkit/blob/v0.3.4/src/account/Safe/SafeAccount.ts#L3124) source code.
+View the identifier generation in the [generateOnChainIdentifier](https://github.com/candidelabs/abstractionkit/blob/v0.4.0/src/account/Safe/SafeAccount.ts#L3458) source code.
 
 ## Indexer patterns
 

--- a/src/data/accountParamAndReturnData.ts
+++ b/src/data/accountParamAndReturnData.ts
@@ -1893,3 +1893,154 @@ export const formatSignaturesToUseroperationsSignaturesReturn = [
     description: "Array of formatted signatures with Merkle proofs, one per UserOperation",
   },
 ];
+
+// v0.7 -> v0.9 module migration (SafeAccountV0_3_0)
+
+export const createMigrateToMultiChainSigParam = [
+  {
+    key: "nodeRpcUrl",
+    type: "string | Transport | JsonRpcNode",
+    description: "The JSON-RPC API URL for the target chain.",
+  },
+  {
+    key: "overrides?",
+    type: [
+      {
+        key: "safeV07ModuleAddress?",
+        type: "string",
+        description: "Override the EntryPoint v0.7 module address to disable.",
+      },
+      {
+        key: "safeV09ModuleAddress?",
+        type: "string",
+        description: "Override the EntryPoint v0.9 module address to enable.",
+      },
+      {
+        key: "prevModuleAddress?",
+        type: "string",
+        description:
+          "Override the linked-list predecessor of the module being disabled. Defaults to an on-chain lookup.",
+      },
+      {
+        key: "modulesStart?",
+        type: "string",
+        description: "Starting address for the module pagination query.",
+      },
+      {
+        key: "modulesPageSize?",
+        type: "bigint",
+        description: "Page size for the module pagination query.",
+      },
+      {
+        key: "skipPreflight?",
+        type: "boolean",
+        description:
+          "Skip the on-chain check that verifies the account is a Safe (>= 1.4.1) running the old module before building the batch. Defaults to false.",
+      },
+    ],
+    description: "Optional overrides for contract addresses, pagination, and the preflight check.",
+  },
+];
+
+export const createMigrateToMultiChainSigReturn = [
+  {
+    key: "MetaTransaction[]",
+    type: [
+      {
+        key: "to",
+        type: "string",
+        description: "The target address for the meta-transaction.",
+      },
+      {
+        key: "data",
+        type: "string",
+        description: "The encoded function call data.",
+      },
+      {
+        key: "value",
+        type: "bigint",
+        description: "The value to send with the meta-transaction (0n for these operations).",
+      },
+    ],
+    description:
+      "Array of meta-transactions that disable the v0.7 module, enable the v0.9 Safe4337MultiChainSignatureModule, and update the fallback handler.",
+  },
+];
+
+export const getFallbackHandlerParams = [
+  {
+    key: "nodeRpcUrl",
+    type: "string | Transport | JsonRpcNode",
+    description: "The JSON-RPC API URL for the target chain.",
+  },
+];
+
+export const getFallbackHandlerReturn = [
+  {
+    key: "fallbackHandler",
+    type: "Promise<string>",
+    description: "Resolves to the address of the active ERC-4337 fallback handler (module) set on the Safe.",
+  },
+];
+
+export const getSafeVersionParams = [
+  {
+    key: "nodeRpcUrl",
+    type: "string | Transport | JsonRpcNode",
+    description: "The JSON-RPC API URL for the target chain.",
+  },
+];
+
+export const getSafeVersionReturn = [
+  {
+    key: "version",
+    type: "Promise<string>",
+    description: 'Resolves to the Safe singleton version string read from VERSION(), e.g. "1.4.1".',
+  },
+];
+
+// estimateUserOperationGas (SafeMultiChainSigAccountV1)
+
+export const estimateUserOperationGasParamMultiChainSig = [
+  {
+    key: "userOperation",
+    type: "UserOperationV9",
+    description: "The UserOperation to estimate gas for.",
+  },
+  {
+    key: "bundlerRpc",
+    type: "string | Transport | Bundler",
+    description: "The bundler RPC URL used to run eth_estimateUserOperationGas.",
+  },
+  {
+    key: "overrides?",
+    type: [
+      {
+        key: "stateOverrideSet?",
+        type: "StateOverrideSet",
+        description: "State overrides passed to the bundler during estimation.",
+      },
+      {
+        key: "dummySignerSignaturePairs?",
+        type: "SignerSignaturePair[]",
+        description: "Dummy signer/signature pairs used as placeholders during estimation.",
+      },
+      {
+        key: "expectedSigners?",
+        type: "Signer[]",
+        description:
+          "The signers whose signatures will be produced at sign time. Used to build dummy signatures when dummySignerSignaturePairs is not provided.",
+      },
+    ],
+    description: "Optional overrides for the estimation, including WebAuthn verifier and signer factory addresses.",
+  },
+];
+
+export const estimateUserOperationGasReturnMultiChainSig = [
+  {
+    key: "[preVerificationGas, verificationGasLimit, callGasLimit]",
+    type: "Promise<[bigint, bigint, bigint]>",
+    description:
+      "Resolves to a tuple of the estimated preVerificationGas, verificationGasLimit, and callGasLimit.",
+  },
+];

--- a/src/data/accountParamAndReturnData.ts
+++ b/src/data/accountParamAndReturnData.ts
@@ -2032,7 +2032,7 @@ export const estimateUserOperationGasParamMultiChainSig = [
           "The signers whose signatures will be produced at sign time. Used to build dummy signatures when dummySignerSignaturePairs is not provided.",
       },
     ],
-    description: "Optional overrides for the estimation, including WebAuthn verifier and signer factory addresses.",
+    description: "Optional overrides for the estimation, such as bundler state overrides and the dummy signatures used while estimating.",
   },
 ];
 

--- a/src/data/utilityParams.ts
+++ b/src/data/utilityParams.ts
@@ -872,3 +872,91 @@ export const createEip7702TransactionHashReturn = [
     description: "The keccak256 hash of the RLP-encoded EIP-7702 transaction with the 0x04 type prefix, used for signing",
   },
 ];
+
+export const getStorageAtParams = [
+  {
+    key: "address",
+    type: "string",
+    description: "The contract address to read storage from.",
+  },
+  {
+    key: "slot",
+    type: "string",
+    description: "The 32-byte storage slot, as a hex string.",
+  },
+  {
+    key: "blockTag?",
+    type: "string | bigint",
+    description: 'Block tag or number to read at. Defaults to "latest".',
+  },
+];
+
+export const getStorageAtReturn = [
+  {
+    key: "word",
+    type: "Promise<string>",
+    description: "Resolves to the 32-byte storage word at the given slot, as a hex string.",
+  },
+];
+
+export const decodeUserOperationRevertReasonParams = [
+  {
+    key: "receipt",
+    type: "UserOperationReceiptResult",
+    description:
+      "A mined UserOperation receipt. The function reads the EntryPoint's UserOperationRevertReason log from it directly, with no extra RPC call.",
+  },
+];
+
+export const decodeUserOperationRevertReasonReturn = [
+  {
+    key: "UserOperationRevert",
+    type: [
+      {
+        key: "reverted",
+        type: "boolean",
+        description: "True when the receipt's success is false.",
+      },
+      {
+        key: "outOfGas",
+        type: "boolean",
+        description:
+          "True when the inner call left no revert data. Usually out-of-gas, though a bare revert()/assert or a call to a non-contract also produce empty data.",
+      },
+      {
+        key: "errorMessage?",
+        type: "string",
+        description: 'Decoded Error("...") string, when the call reverted with a reason.',
+      },
+      {
+        key: "panicCode?",
+        type: "number",
+        description: "Decoded Panic(uint256) code (0x11 overflow, 0x12 divide-by-zero, ...).",
+      },
+      {
+        key: "revertData",
+        type: "string",
+        description: "The raw revert data bytes, for custom errors or further decoding.",
+      },
+    ],
+    description:
+      "The decoded revert reason, matched to the receipt's userOpHash so multi-op bundles return the right entry.",
+  },
+];
+
+export const parseAaCodeParams = [
+  {
+    key: "message",
+    type: "string",
+    description: "An error message string from a failed UserOperation.",
+  },
+];
+
+export const parseAaCodeReturn = [
+  {
+    key: "aaCode",
+    type: "string | undefined",
+    description:
+      'The parsed EntryPoint AAxx revert code (e.g. "AA21"), or undefined when the message contains no AA code.',
+  },
+];


### PR DESCRIPTION
Documents the AbstractionKit **v0.4.0** release across the blog and the SDK reference, and refreshes all source-code anchors to the new tag.

## Blog post
`blog/2026-06-10-abstractionkit-v0-4-0-release` covers the highlights (ethers removed from the runtime, browser/React Native support), the two breaking changes (structured `receipt.logs`, removed IIFE/`unpkg` build), the v0.7→v0.9 module migration helpers, revert-reason/AA-code decoding, and the paymaster/gas correctness fixes.

## New reference entries (previously undocumented public API)
- **`8-safe-account-v3.mdx`**: `createMigrateToSafeMultiChainSigAccountV1MetaTransactions` (v0.7→v0.9 migration), `getFallbackHandler`, `getSafeVersion`
- **`13-safe-unified-account.mdx`**: `SafeMultiChainSigAccountV1.estimateUserOperationGas`
- **`4.utilities.mdx`**: new "Error and revert decoding" section (`decodeUserOperationRevertReason`, `parseAaCode` + the `error.aaCode` shortcut) and `JsonRpcNode.getStorageAt`
- **`14-external-signers.mdx`**: `ExternalSigner` now documents the synchronous `Hex | Promise<Hex>` return
- Backing `DataTable` definitions added to `accountParamAndReturnData.ts` and `utilityParams.ts`

## Source-anchor refresh
All **96** source-code anchors moved from `v0.3.8` (one from `v0.3.4`) to `v0.4.0`. Line numbers were re-verified against the new tag rather than blindly version-bumped: the ethers removal and utils refactor shifted nearly every anchor (e.g. `sendUserOperation` L989→L1078, `signUserOperations` L541→L672).

## Verification
- `yarn build` passes.
- No stale `v0.3.x` anchors remain.
- No em dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Safe module migration tooling from EntryPoint v0.7 to v0.9, including multi-chain gas estimation
  * Added utilities to decode UserOperation revert reasons, parse stable AAxx codes, and read contract storage
  * Added safer gas estimation and enhanced signing helper capabilities
  * Added migration/disable-module pagination support

* **Documentation**
  * Published v0.4.0 release notes blog post and refreshed SDK reference docs/source links
  * Updated external signer documentation to support synchronous signature returns

* **Bug Fixes**
  * Improved paymaster token cost flooring and tightened handling of non-positive exchange rates
  * Fixed verification gas limit multiplier behavior

* **Breaking Changes**
  * Updated `UserOperationReceipt.logs` to use structured `Log[]`
  * Removed the UMD/unpkg browser build and the `ethers` runtime dependency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->