### PR TITLE
docs: document subdomain wildcard support for gas policy domains

### DIFF
--- a/docs/instagas/2-gas-policies.mdx
+++ b/docs/instagas/2-gas-policies.mdx
@@ -41,7 +41,8 @@ InstaGas provides customizable rules for gas policies. These rules are organized
 - **Account Whitelist**: Create an allowlist of accounts eligible for the gas policy. If empty, all accounts are allowed.
     - Example: "Only sponsor transactions from sender `0xabcd...`."
 - **Domains Whitelist**: Create an allowlist of origins eligible for the gas policy. If empty, all origins are allowed.
-    - Example: "Only sponsor transactions originating from `app.uniswap.com`."
+    - Example: "Only sponsor transactions originating from `https://app.uniswap.com`."
+    - Partial wildcards are supported for subdomains, but the protocol scheme is required. `https://*.candide.dev` is accepted; `*.candide.dev` is not.
 - **IP Whitelists**: Create an allowlist of IPs eligible for the gas policy. If empty, all IPs are allowed.
     - Example: "Only sponsor transactions originating from IP `148.156.123.63`."
 


### PR DESCRIPTION
## Summary

The InstaGas gas policy **Domains Whitelist** supports partial wildcards for subdomains, but this was not documented. The previous example also omitted the protocol scheme, which is required.

This clarifies the behavior:
- Adds the scheme to the existing example (`https://app.uniswap.com`).
- Documents that subdomain wildcards work and the scheme is required: `https://*.candide.dev` is accepted; `*.candide.dev` is not.

## Test plan
- [ ] Verify the Access Rules section renders correctly on the InstaGas Gas Policies page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated Access Rules documentation to clarify supported domain whitelist patterns. Wildcard subdomains are now explicitly documented as supported only when the protocol scheme is included (e.g., `https://*.candide.dev`), while partial wildcards without protocols are not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->