### PR TITLE
docs: standardize paymaster env var to PAYMASTER_URL across guides

### DIFF
--- a/docs/wallet/guides/1-send-gasless-tx.mdx
+++ b/docs/wallet/guides/1-send-gasless-tx.mdx
@@ -34,7 +34,7 @@ Add the paymaster configuration to your `.env`:
 
 ```bash title=".env"
 # Paymaster service endpoint
-PAYMASTER_RPC=https://api.candide.dev/public/v3/11155111
+PAYMASTER_URL=https://api.candide.dev/public/v3/11155111
 
 # Optional: Your private gas policy ID (if you created one)
 SPONSORSHIP_POLICY_ID=
@@ -52,7 +52,7 @@ Try public policies first, then fallback to private if no public policy matches
 ```ts title="Public first, private fallback"
 import { Erc7677Paymaster } from "abstractionkit";
 
-const paymasterRPC = process.env.PAYMASTER_RPC as string;
+const paymasterRPC = process.env.PAYMASTER_URL as string;
 const paymaster = new Erc7677Paymaster(paymasterRPC);
 const sponsorshipPolicyId = process.env.SPONSORSHIP_POLICY_ID;
 
@@ -93,7 +93,7 @@ userOperation = paymasterUserOperation;
 
 ```bash
 # Paymaster service endpoint
-PAYMASTER_RPC=https://api.candide.dev/public/v3/11155111
+PAYMASTER_URL=https://api.candide.dev/public/v3/11155111
 
 # Optional: Your private gas policy ID (if you created one)
 SPONSORSHIP_POLICY_ID=
@@ -129,7 +129,7 @@ async function main(): Promise<void> {
     const chainId = BigInt(process.env.CHAIN_ID as string)
     const bundlerUrl = process.env.BUNDLER_URL as string
     const jsonRpcNodeProvider = process.env.JSON_RPC_NODE_PROVIDER as string
-    const paymasterRPC = process.env.PAYMASTER_RPC as string
+    const paymasterRPC = process.env.PAYMASTER_URL as string
     const sponsorshipPolicyId = process.env.SPONSORSHIP_POLICY_ID
     const ownerPublicAddress = process.env.PUBLIC_ADDRESS as string
     const ownerPrivateKey = process.env.PRIVATE_KEY as string
@@ -244,7 +244,7 @@ main().catch(console.error)
 CHAIN_ID=11155111
 BUNDLER_URL=https://api.candide.dev/public/v3/11155111
 JSON_RPC_NODE_PROVIDER=https://ethereum-sepolia-rpc.publicnode.com
-PAYMASTER_RPC=https://api.candide.dev/public/v3/11155111
+PAYMASTER_URL=https://api.candide.dev/public/v3/11155111
 
 # Optional: Your private gas policy ID
 SPONSORSHIP_POLICY_ID=

--- a/docs/wallet/guides/2-pay-gas-in-erc20.mdx
+++ b/docs/wallet/guides/2-pay-gas-in-erc20.mdx
@@ -39,7 +39,7 @@ Token paymasters enable users to pay gas fees with ERC-20 tokens instead of ETH,
 ```ts title="Token paymaster implementation"
 import { Erc7677Paymaster } from "abstractionkit";
 
-const paymasterRPC = process.env.PAYMASTER_RPC as string;
+const paymasterRPC = process.env.PAYMASTER_URL as string;
 const tokenAddress = process.env.TOKEN_ADDRESS as string;
 
 const paymaster = new Erc7677Paymaster(paymasterRPC);
@@ -59,7 +59,7 @@ Get ERC-20 faucet tokens (CTT or USDT) from our [dashboard faucet](https://dashb
 
 ```bash
 # Paymaster service endpoint
-PAYMASTER_RPC=https://api.candide.dev/public/v3/11155111
+PAYMASTER_URL=https://api.candide.dev/public/v3/11155111
 
 # Token address for gas payment (CTT on Sepolia for testing)
 TOKEN_ADDRESS=0xFa5854FBf9964330d761961F46565AB7326e5a3b
@@ -107,7 +107,7 @@ async function main(): Promise<void> {
     const chainId = BigInt(process.env.CHAIN_ID as string)
     const bundlerUrl = process.env.BUNDLER_URL as string
     const jsonRpcNodeProvider = process.env.JSON_RPC_NODE_PROVIDER as string
-    const paymasterRPC = process.env.PAYMASTER_RPC as string
+    const paymasterRPC = process.env.PAYMASTER_URL as string
     const tokenAddress = process.env.TOKEN_ADDRESS as string
     const ownerPublicAddress = process.env.PUBLIC_ADDRESS as string
     const ownerPrivateKey = process.env.PRIVATE_KEY as string
@@ -205,7 +205,7 @@ BUNDLER_URL=https://api.candide.dev/public/v3/11155111
 JSON_RPC_NODE_PROVIDER=https://ethereum-sepolia-rpc.publicnode.com
 
 # Paymaster configuration
-PAYMASTER_RPC=https://api.candide.dev/public/v3/11155111
+PAYMASTER_URL=https://api.candide.dev/public/v3/11155111
 TOKEN_ADDRESS=0xFa5854FBf9964330d761961F46565AB7326e5a3b
 
 # Your EOA credentials

--- a/docs/wallet/guides/7-send-gasless-eip-7702.mdx
+++ b/docs/wallet/guides/7-send-gasless-eip-7702.mdx
@@ -37,7 +37,7 @@ import {
   // highlight-end
 } from "abstractionkit";
 
-const paymasterRPC = process.env.PAYMASTER_RPC as string;
+const paymasterRPC = process.env.PAYMASTER_URL as string;
 const paymaster: Erc7677Paymaster = new Erc7677Paymaster(paymasterRPC);
 const sponsorshipPolicyId = process.env.SPONSORSHIP_POLICY_ID;
 
@@ -75,7 +75,7 @@ userOperation = paymasterUserOperation;
 <TabItem value=".env" label=".env">
 
 ```env
-PAYMASTER_RPC=https://api.candide.dev/public/v3/11155111
+PAYMASTER_URL=https://api.candide.dev/public/v3/11155111
 SPONSORSHIP_POLICY_ID=
 ```
 

--- a/docs/wallet/guides/8-pay-gas-in-erc20-eip-7702.mdx
+++ b/docs/wallet/guides/8-pay-gas-in-erc20-eip-7702.mdx
@@ -29,7 +29,7 @@ import {
   // highlight-end
 } from "abstractionkit";
 
-const paymasterRPC = process.env.PAYMASTER_RPC as string;
+const paymasterRPC = process.env.PAYMASTER_URL as string;
 const tokenAddress = process.env.TOKEN_ADDRESS as string;
 
 const paymaster = new Erc7677Paymaster(paymasterRPC)
@@ -51,7 +51,7 @@ console.log("Please fund the sender account: " + userOperation.sender + " with a
 <TabItem value=".env" label=".env">
 
 ```env
-PAYMASTER_RPC=https://api.candide.dev/public/v3/11155111
+PAYMASTER_URL=https://api.candide.dev/public/v3/11155111
 TOKEN_ADDRESS=0xFa5854FBf9964330d761961F46565AB7326e5a3b # CTT address on sepolia
 ```
 


### PR DESCRIPTION
## What

Standardize the paymaster endpoint environment variable to `PAYMASTER_URL` across all guides.

The `send-gasless-tx`, `pay-gas-in-erc20`, `send-gasless-eip-7702`, and `pay-gas-in-erc20-eip-7702` guides used `PAYMASTER_RPC`, while `getting-started` and every other guide use `PAYMASTER_URL`.

## Why

A developer who follows getting-started sets `PAYMASTER_URL` in `.env`, then copies a snippet from one of these four guides that reads `process.env.PAYMASTER_RPC`, and gets an `undefined` endpoint with no obvious cause. The names should match.

## How this was found

Surfaced by a docs experiment: four agents, each given only the live docs, attempted a real integration (gasless tx, ERC-20 gas, EIP-7702, InstaGas). Two independently hit this env var mismatch. Verified against the docs source before changing: `PAYMASTER_RPC` appeared only in these 4 files.

## Scope

Token rename only (`PAYMASTER_RPC` -> `PAYMASTER_URL`), 4 files, 13 lines. The endpoint values are unchanged. Local variable names (`paymasterRPC`) were left as-is to keep the change minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated paymaster endpoint configuration across wallet guides for gasless transactions, ERC-20 gas payments, and EIP-7702 sponsorship features. All code examples, TypeScript samples, and `.env` configuration snippets now consistently reference the new `PAYMASTER_URL` environment variable for paymaster endpoint setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->