### PR TITLE
docs: link canonical abstractionkit-examples from remaining pages

### DIFF
--- a/docs/wallet/abstractionkit/1.bundler.mdx
+++ b/docs/wallet/abstractionkit/1.bundler.mdx
@@ -61,6 +61,8 @@ Then consume Bundler methods:
 const entrypointAddresses = await bundler.supportedEntryPoints();
 ```
 
+You can also [fork the complete code](https://github.com/candidelabs/abstractionkit-examples/blob/main/bundler/bundler.ts) and follow along.
+
 ### Parameters
 
 #### bundlerRPC `string | Transport`

--- a/docs/wallet/abstractionkit/10-simple-7702-account-v09.mdx
+++ b/docs/wallet/abstractionkit/10-simple-7702-account-v09.mdx
@@ -210,6 +210,8 @@ See [External Signers](/wallet/abstractionkit/external-signers) for the full lis
 
 Builds the EIP-712 typed data payload for a UserOperation under the EntryPoint v0.9 domain. Use this static helper when you need to inspect the wallet prompt payload or drive a custom `signTypedData` primitive directly.
 
+Full example: [`06-typed-data-builder.ts`](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/06-typed-data-builder.ts).
+
 ```ts title="example.ts"
 import { Simple7702AccountV09 } from "abstractionkit";
 
@@ -508,6 +510,8 @@ const signedTransaction = await smartAccount.createRevokeDelegationTransaction(
 </Tabs>
 
 ## Error Handling & Common Issues
+
+For runnable examples that classify and recover from the most common UserOperation failures (underfunded paymaster, insufficient token balance, sponsor denial, on-chain reverts, and gas-too-low retries), see the [error-handling examples](https://github.com/candidelabs/abstractionkit-examples/tree/main/error-handling).
 
 <Tabs>
 <TabItem value="auth-errors" label="Authorization Errors">

--- a/docs/wallet/abstractionkit/11-simple-7702-account-v08.mdx
+++ b/docs/wallet/abstractionkit/11-simple-7702-account-v08.mdx
@@ -38,6 +38,10 @@ import { userOperationReceiptResultType } from "/src/data/userOperation";
 
 The `Simple7702Account` targets **EntryPoint v0.8** and supports the full feature set including gas sponsorship and ERC-20 gas payments through the Candide paymaster.
 
+:::tip Moving to EntryPoint v0.9?
+See the [Simple 7702 Account (EntryPoint v0.9)](/wallet/abstractionkit/simple-7702-account-v09) reference and the [`07-migrate-v08-to-v09.ts`](https://github.com/candidelabs/abstractionkit-examples/blob/main/eip-7702/simple-account/07-migrate-v08-to-v09.ts) example for a complete v0.8 to v0.9 migration.
+:::
+
 export const GETTING_STARTED_ITEMS = [
     {
         title: "EIP-7702 QuickStart",

--- a/docs/wallet/abstractionkit/8-safe-account-v3.mdx
+++ b/docs/wallet/abstractionkit/8-safe-account-v3.mdx
@@ -1027,6 +1027,8 @@ Creates an array of meta-transactions that migrate a deployed Safe from the Entr
 
 Unless `{ skipPreflight: true }` is passed, it first verifies on-chain that the account is a Safe (version `>= 1.4.1`) running the old module, where the module is both enabled and the current fallback handler. This turns a would-be cryptic on-chain `AA23` / `AA24` into a clear up-front error.
 
+Full example: [`migrate-safe-v07-to-v09.ts`](https://github.com/candidelabs/abstractionkit-examples/blob/main/migrate-safe-v07-to-v09/migrate-safe-v07-to-v09.ts).
+
 #### Usage
 
 ```ts

--- a/docs/wallet/guides/0-getting-started.mdx
+++ b/docs/wallet/guides/0-getting-started.mdx
@@ -483,6 +483,8 @@ main()
 - Try a different node endpoint if the current one is down
 - Check your internet connection
 
+For runnable examples that classify and recover from common failures (underfunded paymaster, insufficient token balance, sponsor denial, on-chain reverts, and gas-too-low retries), see the [error-handling examples](https://github.com/candidelabs/abstractionkit-examples/tree/main/error-handling).
+
 #### Getting Help
 
 If you're still stuck:


### PR DESCRIPTION
Audited every guide and SDK page against [abstractionkit-examples](https://github.com/candidelabs/abstractionkit-examples). Most pages already linked their canonical example (and all existing links point to real files). This fills the remaining gaps where an example existed but wasn't surfaced from its natural doc home.

## Changes

| Doc page | Now links to |
|---|---|
| Bundler SDK reference | `bundler/bundler.ts` |
| Simple 7702 v0.9 → typed-data section | `06-typed-data-builder.ts` |
| Simple 7702 v0.9 → error-handling section | `error-handling/` examples |
| Simple 7702 v0.8 (intro) | `07-migrate-v08-to-v09.ts` + v0.9 reference |
| Safe Account v3 → migration method | `migrate-safe-v07-to-v09.ts` |
| Getting Started → Troubleshooting | `error-handling/` examples |

Links follow the existing "fork the complete code" / "Full example" style used on the Getting Started page.

## Notes

- **Not touched:** `nested-safe-accounts.ts` has no corresponding doc page; linking it would require writing new content.
- **Left as-is:** `4-signing.mdx` (no matching example for EIP-1271 message signing) and `5-authentication.mdx` (overview page that already routes to the External Signers reference and other guides with example links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Enhanced documentation with additional example references and troubleshooting guidance across Bundler, Safe Account, and 7702 Account sections.
* Added links to full runnable examples for UserOperation typed-data builders and account migrations.
* Introduced comprehensive error-handling examples in Getting Started guide covering common failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->