### PR TITLE
docs: update banner to mention Somnia, HyperEVM, and Tempo

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -183,9 +183,9 @@ const config = {
       },
       image: 'img/posters/atelier-meta.png',
       announcementBar: {
-        id: 'abstractionkit-v0-3-0',
+        id: 'new-chains-somnia-hyperevm-tempo',
         content:
-          'AbstractionKit v0.3.0 is out: Safe Unified Account audited, Calibur Account, and parallelizable paymaster signing. <a href="/blog/abstractionkit-v0-3-0-release">Read the release</a>',
+          'Now live on Somnia, HyperEVM, and Tempo. <a href="/wallet/bundler/rpc-endpoints">See all supported networks</a>',
         backgroundColor: '#fce7f0',
         textColor: '#1a1a1a',
         isCloseable: true,


### PR DESCRIPTION
## What

Updates the announcement banner (`announcementBar`) to highlight the newly supported chains instead of the AbstractionKit v0.3.0 release.

- New copy: *Now live on Somnia, HyperEVM, and Tempo.* with a link to the [supported networks](/wallet/bundler/rpc-endpoints) page
- Bumped the banner `id` so users who dismissed the previous announcement will see this one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the site announcement banner with information about Somnia, HyperEVM, and Tempo, along with a link to supported networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->