### PR TITLE
[codex] Promote forwarding address docs

### DIFF
--- a/blog/2023-05-11-voltaire-bundler/index.mdx
+++ b/blog/2023-05-11-voltaire-bundler/index.mdx
@@ -20,7 +20,7 @@ Voltaire is open-source, meaning that anyone can launch Voltaire and capture Use
 :::info
 Get started by getting bundler endpoints for your development [here](/wallet/bundler/rpc-methods)
 :::
-ERC-4337 developers can get started sending [UserOperations requests](/wallet/bundler/rpc-endpoints) for Sepolia, Goerli, and Optimism-Goerli testnet. Stay tuned for more networks coming soon.
+ERC-4337 developers can get started sending [UserOperations requests](/wallet/api/supported-networks/) for Sepolia, Goerli, and Optimism-Goerli testnet. Stay tuned for more networks coming soon.
 
 We partnered with BlockPi, Chainbase, and LlamaNodes to offer low-latency and resilient ERC-4337 compliant public hosted bundlers using Voltaire.
 

--- a/blog/2024-09-12-voltaire-entrypoint-v7-support/index.mdx
+++ b/blog/2024-09-12-voltaire-entrypoint-v7-support/index.mdx
@@ -39,7 +39,7 @@ Voltaire’s advanced gas estimation ensures that users and developers alike can
 
 ## Getting Started with Voltaire
 
-Getting started with Voltaire is completely easy and at no cost. Developers can begin by testing their applications with [free testnet support](/wallet/bundler/rpc-endpoints/) across multiple networks. Once ready for mainnet deployment, Voltaire offers flexible subscription plans designed to meet the needs of solo developers, startups, and enterprises. These plans provide scalable access to advanced features such as higher API rate limits, a larger number of API requests, and dedicated support. Voltaire is open-source, so self-hosting is encouraged if desired. 
+Getting started with Voltaire is completely easy and at no cost. Developers can begin by testing their applications with [free testnet support](/wallet/api/supported-networks/) across multiple networks. Once ready for mainnet deployment, Voltaire offers flexible subscription plans designed to meet the needs of solo developers, startups, and enterprises. These plans provide scalable access to advanced features such as higher API rate limits, a larger number of API requests, and dedicated support. Voltaire is open-source, so self-hosting is encouraged if desired. 
 
 Voltaire Bundler is coming soon as self-served on the Dashboard. In the meantime, you can reach out directly to get Mainnet Access via [Discord](https://discord.gg/8q2H6BEJuf), or by emailing [**team@candidelabs.com**](mailto:team@candidelabs.com). The team guarantees a same-day response.
 

--- a/docs/account-abstraction/research/eil.md
+++ b/docs/account-abstraction/research/eil.md
@@ -75,7 +75,7 @@ One signature authorizes operations across all chains. Users sign once, and coor
 
 A single address that works on every chain. Users share one address, receive funds from any network, and assets automatically route to their preferred destination. EIL powers the trustless routing without any custody intermediaries.
 
-[Learn more about Forwarding Address →](/account-abstraction/research/multichain-deposit-address)
+[Learn more about Forwarding Address →](/forwarding-address/overview)
 
 ### SDK Integration
 

--- a/docs/forwarding-address/api-reference.mdx
+++ b/docs/forwarding-address/api-reference.mdx
@@ -7,14 +7,10 @@ keywords:
   - json-rpc
   - cross-chain
   - deposit-address
-  - alpha
+  - production
 ---
 
 # Forwarding Address API Reference
-
-:::caution Alpha
-The Forwarding Address API is in alpha. Breaking changes are expected. Do not move large amounts of funds through forwarding addresses during the alpha period.
-:::
 
 ## Protocol
 
@@ -155,7 +151,7 @@ Parameters:
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `recipient` | `address` | Yes | Destination address that receives forwarded tokens |
-| `custodialWithdrawer` | `address` | Yes | Emergency recovery address that can withdraw stuck funds after a timelock. For most integrations, use the platform's address. See [custodialWithdrawer](./forwarding-address-guide.mdx#the-custodialwithdrawer-role) |
+| `custodialWithdrawer` | `address` | Yes | Emergency recovery address that can withdraw stuck funds after a timelock. For most integrations, use the platform's address. See [custodialWithdrawer](./integration-guide.mdx#the-custodialwithdrawer-role) |
 | `destinationChainId` | `number` | Yes | Target chain ID where assets will be delivered |
 | `salt` | `bytes32` | No | Optional 32-byte hex value. Use different salts to generate multiple forwarding addresses for the same recipient |
 
@@ -207,7 +203,7 @@ Parameters:
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `recipient` | `address` | Yes | Destination recipient address |
-| `custodialWithdrawer` | `address` | Yes | Withdrawal-authorized address. See [custodialWithdrawer](./forwarding-address-guide.mdx#the-custodialwithdrawer-role) |
+| `custodialWithdrawer` | `address` | Yes | Withdrawal-authorized address. See [custodialWithdrawer](./integration-guide.mdx#the-custodialwithdrawer-role) |
 | `destinationChainId` | `number` | Yes | Target chain ID |
 | `sourceChainIds` | `number[]` | Yes | Array of source chain IDs to activate monitoring on |
 | `salt` | `bytes32` | No | Optional salt (must match the one used in `forwarding_getAddress`) |
@@ -499,8 +495,6 @@ interface EstimateResult {
 ---
 
 ## Changelog
-
-The Forwarding Address API is in alpha and evolves quickly. Breaking changes and new capabilities are tracked here so integrators can see what to update.
 
 ### 2026-05-06
 

--- a/docs/forwarding-address/integration-guide.mdx
+++ b/docs/forwarding-address/integration-guide.mdx
@@ -7,23 +7,10 @@ keywords:
   - guide
   - cross-chain
   - deposit-address
-  - alpha
+  - production
 ---
 
 # Forwarding Address Integration Guide
-
-<div style={{maxWidth: "720px"}}>
-  <div style={{position: "relative", paddingBottom: "56.25%", height: 0, overflow: "hidden", borderRadius: "12px"}}>
-    <iframe
-      style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}
-      src="https://www.youtube.com/embed/S1fttTLzUuo"
-      title="Forwarding Address Technical Explainer"
-      frameBorder="0"
-      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-      allowFullScreen
-    />
-  </div>
-</div>
 
 ## Typical Integration Flow
 
@@ -35,12 +22,12 @@ flowchart TD
     D --> E[Watch for status on destination chain]
 ```
 
-See the [API Reference](./forwarding-address-api.mdx) for details on each method. 
+See the [API Reference](./api-reference.mdx) for details on each method. 
 
 import Callout from "/src/components/Callout";
 
 <Callout title="Authentication">
-The activation call ([`account_activateForwardingAddress`](./forwarding-address-api.mdx#account_activateforwardingaddress)) requires `Authorization: Bearer <account_api_key>`. Account API keys are issued by Candide; every other method is public.
+The activation call ([`account_activateForwardingAddress`](./api-reference.mdx#account_activateforwardingaddress)) requires `Authorization: Bearer <account_api_key>`. Account API keys are issued by Candide; every other method is public.
 </Callout>
 
 ---
@@ -93,9 +80,9 @@ If funds are stuck, use the [recovery frontend](https://forwarding-address.candi
 
 ## Gotchas
 
-- Deposits below the per-bridge minimum are not forwarded. Query [`forwarding_getMinimumAmount`](./forwarding-address-api.mdx#forwarding_getminimumamount) for the route and token to validate user input, and display the minimum clearly in your UI.
+- Deposits below the per-bridge minimum are not forwarded. Query [`forwarding_getMinimumAmount`](./api-reference.mdx#forwarding_getminimumamount) for the route and token to validate user input, and display the minimum clearly in your UI.
 - Only tokens listed in the route's `tokens` array are forwarded. Unsupported tokens sent to the address require manual recovery.
 - The forwarding address accepts deposits on any supported chain, including the destination chain. Do not send on unsupported chains. Check `forwarding_getRoutes` for the full list of supported chains per route.
-- The output token on the destination chain may have different decimals than the input token. Use the token's `decimals` from [`forwarding_getRoutes`](./forwarding-address-api.mdx#forwarding_getroutes) when formatting amounts.
+- The output token on the destination chain may have different decimals than the input token. Use the token's `decimals` from [`forwarding_getRoutes`](./api-reference.mdx#forwarding_getroutes) when formatting amounts.
 - Cache `forwarding_getRoutes` on app load and refresh periodically. Routes, fees, and supported tokens can change.
 - The activation call needs an account API key (`Authorization: Bearer ...`). All other methods are public. Each account can have up to 500 active forwarding addresses; exceeding the cap returns error `-32013`.

--- a/docs/forwarding-address/overview.mdx
+++ b/docs/forwarding-address/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Forwarding Address"
-description: "A forwarding address that works across all blockchains, enabling instant cross-chain asset routing"
+description: "Let users deposit into one forwarding address from any supported chain and receive funds on their destination chain."
 keywords:
   - cross-chain
   - forwarding
@@ -14,11 +14,9 @@ keywords:
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-# Forwarding Address: One Address for Every Chain
+# Forwarding Address for Onramps and Deposits
 
-*Universal deposit addresses for wallets, on-ramp flows, and payment apps.*
-
-Users share one address. Senders pay from any supported chain. Funds arrive on the user's preferred destination chain.
+Let users deposit into one address from any supported chain and receive funds on their destination chain.
 
 <div style={{maxWidth: "720px"}}>
   <div style={{position: "relative", paddingBottom: "56.25%", height: 0, overflow: "hidden", borderRadius: "12px"}}>
@@ -35,6 +33,8 @@ Users share one address. Senders pay from any supported chain. Funds arrive on t
 
 <br />
 
+Use Forwarding Address for onboarding, onramp, exchange withdrawal, and payment flows where the sender's source chain may not match the user's destination chain. The user receives one deposit address; Candide routes supported deposits to the destination wallet automatically.
+
 **Try it**: [forwarding-address.candidelabs.com](https://forwarding-address.candidelabs.com)
 
 ## Start Integrating
@@ -43,8 +43,6 @@ Install the Candide skills so your AI agent knows how to wire up the Forwarding 
 
 <Tabs>
 <TabItem value="claude" label="Claude Code">
-
-Run inside Claude Code:
 
 ```
 /plugin marketplace add candidelabs/skills
@@ -74,7 +72,7 @@ https://raw.githubusercontent.com/candidelabs/skills/main/skills/forwarding-addr
 </TabItem>
 </Tabs>
 
-For manual reference: [API Reference](./forwarding-address-api.mdx) | [Integration Guide](./forwarding-address-guide.mdx)
+For manual reference: [API Reference](./api-reference.mdx) | [Integration Guide](./integration-guide.mdx)
 
 ## Why It Matters
 
@@ -96,12 +94,6 @@ Funds route through self-custodial smart contracts. Integrators can configure a 
 - Wallets that want one deposit address per user.
 - On-ramp and exchange funding flows where supported withdrawal chains vary.
 - Payment apps where sender and recipient may operate on different chains.
-
-## Build With Us
-
-We're looking for wallet and payment teams who want to offer seamless cross-chain receiving to their users.
-
-Reach out directly on Telegram: **[@heymarcopolo](https://t.me/heymarcopolo)**
 
 ---
 

--- a/docs/wallet/abstractionkit/1.bundler.mdx
+++ b/docs/wallet/abstractionkit/1.bundler.mdx
@@ -25,7 +25,7 @@ import { userOperationReturnParamsV06, userOperationParamV07, userOperationParam
 
 The `Bundler` class provides access to ERC-4337 Bundler JSON-RPC API methods for estimating user operation gas and sending user operations.
 
-The `Bundler` class creates a Bundler instance with a [Bundler RPC URL](/wallet/bundler/rpc-endpoints/) or an EIP-1193-shaped `Transport`.
+The `Bundler` class creates a Bundler instance with a [Bundler RPC URL](/wallet/api/supported-networks/) or an EIP-1193-shaped `Transport`.
 
 ## Usage
 

--- a/docs/wallet/api/public-endpoints.md
+++ b/docs/wallet/api/public-endpoints.md
@@ -26,7 +26,7 @@ https://api.candide.dev/public/v3/11155111
 
 ## Supported Networks
 
-See the list of [supported networks](/wallet/bundler/rpc-endpoints/).
+See the list of [supported networks](/wallet/api/supported-networks/).
 
 ## Supported Methods
 

--- a/docs/wallet/api/supported-networks.mdx
+++ b/docs/wallet/api/supported-networks.mdx
@@ -1,7 +1,7 @@
 ---
-slug: rpc-endpoints
-title: Candide's Supported Networks
-description: Candide supports 10+ EVM chains and growing. 
+slug: supported-networks
+title: Supported Networks
+description: Supported networks for Candide Bundler and Paymaster endpoints.
 image: /img/posters/voltaire-meta.png
 authors: [sherif]
 ---

--- a/docs/wallet/atelier-intro.mdx
+++ b/docs/wallet/atelier-intro.mdx
@@ -101,7 +101,7 @@ import { NetworkList } from "/src/components/NetworkList";
 
 <NetworkList />
 
-See the full list of [supported networks](/wallet/bundler/rpc-endpoints/), including testnets and exclusive networks.
+See the full list of [supported networks](/wallet/api/supported-networks/), including testnets and exclusive networks.
 
 ## Support & Feedback
 

--- a/docs/wallet/bundler/0-erc-4337-intro.md
+++ b/docs/wallet/bundler/0-erc-4337-intro.md
@@ -9,7 +9,7 @@ image: /img/posters/voltaire-meta.png
 Voltaire is a modular, developer-friendly, and lightning-fast Python Bundler for Ethereum EIP-4337 Account Abstraction.
 
 :::info
-Looking for a quick bundler instance? Use one of our [public hosted endpoints](./3-rpc-endpoints.mdx) for development.
+Looking for a quick bundler instance? Use one of our [public hosted endpoints](/wallet/api/public-endpoints/) for development.
 :::
 
 Voltaire is a fully open-source project designed to operate within the peer-to-peer mempool of UserOperations, enabling faster and more efficient on-chain transaction inclusion.

--- a/docs/wallet/guides/recovery-with-google-using-lit.mdx
+++ b/docs/wallet/guides/recovery-with-google-using-lit.mdx
@@ -42,7 +42,7 @@ Configure the values you created from Lit dashboard in an .env file
 LIT_API_KEY=Request Relay Server API Key from Lit at https://forms.gle/RNZYtGYTY9BcD9MEA
 
 // Candide
-BUNDLER_URL="https://api.candide.dev/public/v3/11155111" // Other networks are found here: https://docs.candide.dev/wallet/bundler/rpc-endpoints
+BUNDLER_URL="https://api.candide.dev/public/v3/11155111" // Other networks are found here: https://docs.candide.dev/wallet/api/supported-networks
 PAYMASTER_URL="Request an API key from Candide on Discord"
     
 // Generate a Public/Private Key

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -161,6 +161,26 @@ const config = {
       {
         redirects: [
           {
+            from: '/wallet/bundler/rpc-endpoints/',
+            to: '/wallet/api/supported-networks/',
+          },
+          {
+            from: '/wallet/bundler/public-endpoints/',
+            to: '/wallet/api/public-endpoints/',
+          },
+          {
+            from: '/account-abstraction/research/multichain-deposit-address/',
+            to: '/forwarding-address/overview/',
+          },
+          {
+            from: '/account-abstraction/research/forwarding-address-api/',
+            to: '/forwarding-address/api-reference/',
+          },
+          {
+            from: '/account-abstraction/research/forwarding-address-guide/',
+            to: '/forwarding-address/integration-guide/',
+          },
+          {
             from: '/account-abstraction/research/safe-unified-account/',
             to: '/wallet/guides/chain-abstraction-overview/',
           },
@@ -185,7 +205,7 @@ const config = {
       announcementBar: {
         id: 'new-chains-somnia-hyperevm-tempo',
         content:
-          'Now live on Somnia, HyperEVM, and Tempo. <a href="/wallet/bundler/rpc-endpoints">See all supported networks</a>',
+          'Now live on Somnia, HyperEVM, and Tempo. <a href="/wallet/api/supported-networks">See all supported networks</a>',
         backgroundColor: '#fce7f0',
         textColor: '#1a1a1a',
         isCloseable: true,
@@ -217,15 +237,20 @@ const config = {
           {
             to: '/wallet/plugins/passkeys',
             position: 'left',
-            label: 'Plugins',
+            label: 'Safe Account Plugins',
           },
           {
-            to: '/wallet/bundler/rpc-endpoints',
+            to: '/forwarding-address/overview',
+            position: 'left',
+            label: 'Forwarding Address',
+          },
+          {
+            to: '/wallet/api/supported-networks',
             position: 'left',
             label: 'API',
           },
           {
-            to: '/account-abstraction/research/multichain-deposit-address',
+            to: '/account-abstraction/research/eil',
             position: 'left',
             label: 'Labs',
           },

--- a/sidebars.js
+++ b/sidebars.js
@@ -17,16 +17,51 @@ const sidebars = {
 
   // But you can create a sidebar manually
   aaSideBar: ["account-abstraction/intro"],
+  forwardingAddressSideBar: [
+    {
+      type: "category",
+      label: "Forwarding Address",
+      className: "category-not-collapsible",
+      collapsible: false,
+      collapsed: false,
+      items: [
+        {
+          type: "doc",
+          id: "forwarding-address/overview",
+          label: "Overview"
+        },
+        {
+          type: "doc",
+          id: "forwarding-address/integration-guide",
+          label: "Integration Guide"
+        },
+        {
+          type: "doc",
+          id: "forwarding-address/api-reference",
+          label: "API Reference"
+        },
+      ],
+    },
+  ],
   infraSideBar: [
     {
-      type: "doc",
-      id: "wallet/bundler/rpc-endpoints",
-      label: "Supported Networks"
-    },
-    {
-      type: "doc",
-      id: "wallet/bundler/public-endpoints",
-      label: "Public Endpoints"
+      type: "category",
+      label: "Bundler & Paymaster",
+      className: "category-not-collapsible",
+      collapsible: false,
+      collapsed: false,
+      items: [
+        {
+          type: "doc",
+          id: "wallet/api/supported-networks",
+          label: "Supported Networks"
+        },
+        {
+          type: "doc",
+          id: "wallet/api/public-endpoints",
+          label: "Public Endpoints"
+        },
+      ],
     },
     {
       type: "category",
@@ -628,28 +663,6 @@ const sidebars = {
       className: "category-not-collapsible",
       label: "Labs",
       items: [
-        {
-          type: "category",
-          label: "Forwarding Address",
-          collapsed: true,
-          items: [
-            {
-              type: "doc",
-              id: "account-abstraction/research/multichain-deposit-address",
-              label: "Overview"
-            },
-            {
-              type: "doc",
-              id: "account-abstraction/research/forwarding-address-api",
-              label: "API Reference"
-            },
-            {
-              type: "doc",
-              id: "account-abstraction/research/forwarding-address-guide",
-              label: "Integration Guide"
-            },
-          ],
-        },
         {
           type: "doc",
           id: "account-abstraction/research/eil",


### PR DESCRIPTION
## Summary

Promotes Forwarding Address out of Labs into a first-class docs section with its own navbar entry, sidebar, and canonical `/forwarding-address/...` routes.

Also moves shared Bundler/Paymaster endpoint pages out of the Bundler folder into `/wallet/api/...`, updates internal links to the new canonical routes, and keeps old URLs working with redirects.

## Changes

- Added a dedicated Forwarding Address navbar entry and sidebar.
- Moved Forwarding Address docs from `account-abstraction/research` to `forwarding-address`.
- Clarified the overview copy around onramp/deposit flows.
- Added redirects for old Forwarding Address Labs URLs.
- Moved shared Supported Networks and Public Endpoints pages to `wallet/api`.
- Added redirects for old Bundler-specific shared API URLs.
- Renamed the navbar label from `Plugins` to `Safe Account Plugins`.

## Validation

- `yarn build`
