### PR TITLE
docs: fix type-table markdown export and add llms-full.txt

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -144,6 +144,7 @@ const config = {
         siteTitle: 'Candide Account Abstraction',
         siteDescription: 'Candide Ethereum Account Abstraction developer tools for building smart accounts',
         content: {
+          enableLlmsFullTxt: true,  // Generate llms-full.txt with full page content
           relativePaths: false,  // Use absolute URLs instead of relative paths
           includeBlog: false,    // Already false by default
           includePages: false,   // Exclude tag/other pages

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -39,22 +39,35 @@ export default function Table({
 
 // Function to render the value based on its type
 function renderValue(value) {
-  if (Array.isArray(value)) {
-    return (
-      <DataTable items={value}/>
-    );
-  } else {
-    return <span>{String(value)}</span>;
-  }
+  return <span>{String(value)}</span>;
+}
+
+// Nested type definitions (a row whose `type` is an array of rows) are
+// flattened into dotted-path rows: nested <table> elements inside cells do
+// not survive the HTML-to-markdown conversion that produces llms.txt.
+function flattenItems(items, prefix = "") {
+  return items.flatMap((item) => {
+    const key = item.key === undefined ? "" : String(item.key);
+    const fullKey = prefix && key ? `${prefix}.${key}` : key || prefix;
+    if (Array.isArray(item.type)) {
+      return [
+        { ...item, key: fullKey, type: "object" },
+        ...flattenItems(item.type, fullKey),
+      ];
+    }
+    return [{ ...item, key: fullKey }];
+  });
 }
 
 // Main DataTable component
 export function DataTable({ items }) {
   if (!items || items.length === 0) return null;
 
+  const rows = flattenItems(items);
+
   // Extract all unique keys from the data
   const allKeys = Array.from(
-    new Set(items.flatMap((item) => Object.keys(item)))
+    new Set(rows.flatMap((item) => Object.keys(item)))
   );
 
   return (
@@ -69,7 +82,7 @@ export function DataTable({ items }) {
         </tr>
       </thead>
       <tbody>
-        {items.map((item, rowIndex) => (
+        {rows.map((item, rowIndex) => (
           <tr key={rowIndex}>
             {allKeys.map((key, colIndex) => (
               <td key={colIndex} align="left" style={{ padding: "8px" }}>


### PR DESCRIPTION
## What

Two fixes to the machine-readable docs surface that agents consume:

1. **Nested type tables now survive the markdown export.** `DataTable` rendered nested type definitions (MetaTransaction, WebauthnPublicKey, override objects) as tables inside table cells. GFM cannot nest tables, so the llms.txt pipeline flattened them into single-cell tab-delimited blobs, making the most load-bearing types the least legible to agents. Nested rows are now flattened to dotted-path rows (`MetaTransaction.to`, `MetaTransaction.value`, ...) which render cleanly on the site and in the exports.

2. **`llms-full.txt` is now generated** (plugin option `enableLlmsFullTxt`), so agents can fetch the entire docs corpus in a single file alongside the existing `llms.txt` index.

## Verification

`yarn build` passes. Checked `build/wallet/abstractionkit/safe-unified-account.md`: previously mangled MetaTransaction rows now export as a proper GFM table. `build/llms-full.txt` generated (1.6 MB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled generation of a full `llms-full.txt` documentation file for the site.

* **Bug Fixes**
  * Improved table display for nested row data, making complex tables render more consistently.
  * Simplified value rendering so plain values now appear as standard text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->