### PR TITLE
docs: document authenticated endpoints and API key usage

### DIFF
--- a/docs/instagas/6-batch-sponsor-transactions.mdx
+++ b/docs/instagas/6-batch-sponsor-transactions.mdx
@@ -156,7 +156,7 @@ const { sendCalls, data: id } = useSendCalls(); // to send batch & sponsored tx
 const { sendTransaction } = useSendTransaction(); // to send standard tx
 const chainId = useChainId();
 
-const paymasterUrl = "https://api.candide.dev/paymaster/v3/network/APY_KEY";
+const paymasterUrl = "https://api.candide.dev/api/v3/CHAIN_ID/API_KEY";
 const sponsorshipPolicyId = process.env.SPONSORSHIP_POLICY_ID;
 
 const tx = {

--- a/docs/wallet/api/authenticated-endpoints.md
+++ b/docs/wallet/api/authenticated-endpoints.md
@@ -24,14 +24,9 @@ https://api.candide.dev/api/v3/11155111/YOUR_API_KEY
 
 The API key is a path segment: there are no separate auth headers. Treat the full URL as a secret.
 
-### Legacy formats
-
-Earlier integrations used separate per-service URLs with chain names. These remain fully supported, but new integrations should use the unified format above.
-
-```
-https://api.candide.dev/bundler/v3/{CHAIN_NAME}/{API_KEY}
-https://api.candide.dev/paymaster/v3/{CHAIN_NAME}/{API_KEY}
-```
+:::caution
+The older per-service URL formats (`/bundler/v3/` and `/paymaster/v3/` with chain names) are deprecated. Use the unified format above.
+:::
 
 ## Example Request
 

--- a/docs/wallet/api/authenticated-endpoints.md
+++ b/docs/wallet/api/authenticated-endpoints.md
@@ -1,0 +1,82 @@
+---
+slug: authenticated-endpoints
+title: API Keys & Endpoints
+description: Authenticated Bundler and Paymaster endpoints for production. URL format, API key setup, and rate limits.
+image: /img/posters/voltaire-meta.png
+keywords: [api key, bundler endpoint, paymaster endpoint, authentication, rate limits]
+---
+
+Production integrations use authenticated endpoints with an API key. Get yours from [Candide's Dashboard](https://dashboard.candide.dev). No sales call required.
+
+## Endpoint URL Format
+
+One URL serves both the **Bundler** and **Paymaster** APIs. Add the chain ID and your API key:
+
+```
+https://api.candide.dev/api/v3/{CHAIN_ID}/{API_KEY}
+```
+
+**Example (Sepolia Testnet - Chain ID 11155111):**
+
+```
+https://api.candide.dev/api/v3/11155111/YOUR_API_KEY
+```
+
+The API key is a path segment: there are no separate auth headers. Treat the full URL as a secret.
+
+### Legacy formats
+
+Earlier integrations used separate per-service URLs with chain names. These remain fully supported, but new integrations should use the unified format above.
+
+```
+https://api.candide.dev/bundler/v3/{CHAIN_NAME}/{API_KEY}
+https://api.candide.dev/paymaster/v3/{CHAIN_NAME}/{API_KEY}
+```
+
+## Example Request
+
+```bash
+curl https://api.candide.dev/api/v3/11155111/YOUR_API_KEY \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "eth_supportedEntryPoints", "params": []}'
+```
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": [
+    "0x433709009B8330FDa32311DF1C2AFA402eD8D009",
+    "0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108",
+    "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
+  ]
+}
+```
+
+## Using with AbstractionKit
+
+Pass the same URL wherever the SDK expects a bundler or paymaster endpoint:
+
+```typescript
+import { Bundler, CandidePaymaster } from "abstractionkit";
+
+const endpoint = `https://api.candide.dev/api/v3/${chainId}/${apiKey}`;
+
+const bundler = new Bundler(endpoint);
+const paymaster = new CandidePaymaster(endpoint);
+```
+
+## Supported Methods & Networks
+
+The full [Bundler API](/wallet/bundler/rpc-methods/) and [Paymaster API](/wallet/paymaster/rpc-methods/) are available on every [supported network](/wallet/api/supported-networks/).
+
+## Rate Limits
+
+Authenticated endpoints have higher rate limits than the [public endpoints](/wallet/api/public-endpoints/), scaled to your plan. UserOperation allotments per tier are listed on the [pricing page](/wallet/pricing/). If you hit a `Too Many Requests` error in production, [reach out](https://t.me/heymarcopolo) and we will look at your usage pattern together.
+
+## Key Safety
+
+- Keep keys out of client-side code where possible. For frontend paymaster flows, scope what a key can sponsor with [gas policies](/instagas/gas-policies/) so a leaked key cannot drain your gas tank.
+- The repository holding your key config should never commit the full endpoint URL.
+- If a key leaks, issue a new one from the [dashboard](https://dashboard.candide.dev), update your deployments, and remove the old key.

--- a/docs/wallet/api/public-endpoints.md
+++ b/docs/wallet/api/public-endpoints.md
@@ -37,5 +37,5 @@ See the list of the [Bundler API](/wallet/bundler/rpc-methods/) and [Paymaster A
 To keep things running smoothly for everyone, we limit the number of requests you can make from a single IP address. If you send too many requests, you'll get a `Too Many Requests` error.
 
 :::info
-Need Higher Limits? For production use or higher rate limits, signup on [Candide's Dashboard](https://dashboard.candide.dev) to get your own Bundler and Paymaster URLs.
+Need Higher Limits? For production use or higher rate limits, signup on [Candide's Dashboard](https://dashboard.candide.dev) to get your own Bundler and Paymaster URLs. See [API Keys & Endpoints](/wallet/api/authenticated-endpoints/) for the URL format and setup.
 :::

--- a/sidebars.js
+++ b/sidebars.js
@@ -58,6 +58,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "wallet/api/authenticated-endpoints",
+          label: "API Keys & Endpoints"
+        },
+        {
+          type: "doc",
           id: "wallet/api/public-endpoints",
           label: "Public Endpoints"
         },


### PR DESCRIPTION
## What

The authenticated endpoint contract existed only in the July 2025 release blog post; the docs told developers to "get your URL from the dashboard" without ever showing the URL format. This adds `wallet/api/authenticated-endpoints`:

- Unified URL format `https://api.candide.dev/api/v3/{CHAIN_ID}/{API_KEY}` serving both Bundler and Paymaster; the old per-service formats are marked deprecated (per Marco), and the one code example still using them (InstaGas batch-sponsor page) is updated to the unified format
- A keyed curl example with the documented `eth_supportedEntryPoints` response
- AbstractionKit usage (same URL into `Bundler` and `CandidePaymaster`)
- Rate limit guidance and key safety notes (scoping frontend keys with gas policies)
- Sidebar entry under Bundler & Paymaster, cross-link from Public Endpoints

## Needs your input before merge

Rate limits are still qualitative. If you can share numbers (public per-IP limit, per-tier request ceilings), I'll add a table; the section is structured to take one.

## Verification

`yarn build` passes with no broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide for authenticated wallet API production endpoints, including the unified URL format, request/response examples, supported networks/methods, and authenticated rate-limit guidance.
  * Added safety practices for API key handling and noted deprecated legacy endpoint formats.
  * Updated the public endpoints rate-limit section to direct users to the authenticated setup.
  * Corrected an Instagas example paymaster endpoint URL to the new authenticated API format.
* **Chores**
  * Updated site navigation to include the new “API Keys & Endpoints” documentation page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
