### PR TITLE
docs: add machine-readable InstaGas policy object reference

### DIFF
--- a/docs/instagas/2-gas-policies.mdx
+++ b/docs/instagas/2-gas-policies.mdx
@@ -86,3 +86,109 @@ For each function, you can specify a list of parameters, and each parameter can 
 * `tokenOut`: equal to WETH (e.g., `tokenOut == weth`)
 
 By specifying these constraints, you can control the behavior of the swap transaction and ensure that it is executed according to your requirements. For instance, you can ensure that the swap transaction only occurs if the amount being swapped is greater than 350, and if the tokens being swapped are USDT and WETH.
+
+## Policy Object Reference
+
+Policies are created and edited in the [dashboard](https://dashboard.candide.dev). This section defines the underlying policy object precisely, so you can plan a configuration before opening the dashboard, review an existing one, or have an AI agent draft the exact values to enter.
+
+```json
+{
+  "name": "Onboarding sponsorship",
+  "chainId": 10,
+  "generalPolicy": {
+    "enabled": true,
+    "private": false,
+    "policyId": "175c73...",
+    "startDate": 1751500800000,
+    "endDate": 1754179200000
+  },
+  "accountPolicy": {
+    "totalMax": "0x6f05b59d3b20000",
+    "maxPerOp": "0x5af3107a4000",
+    "rate": 3,
+    "ratePeriod": 86400
+  },
+  "accessPolicy": {
+    "whitelistedAccounts": [
+      { "address": "0xA1b2C3d4E5f6A7b8C9d0E1f2A3b4C5d6E7f8A9b0", "label": "Beta tester" }
+    ],
+    "whitelistedOrigins": [
+      { "origin": "https://*.example.com", "label": "Our app" }
+    ],
+    "whitelistedIPs": []
+  },
+  "transactionsPolicy": {
+    "transactions": [
+      {
+        "to": "0xE592427A0AEce92De3Edee1F18E0157C05861564",
+        "selector": "0x414bf389",
+        "abi": "{\"name\": \"exactInputSingle\", \"type\": \"function\", ...}",
+        "params": [
+          { "indexes": [0, 5], "operator": "$gte", "value": "1000000" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### General
+
+| field | type | description |
+| :--- | :--- | :--- |
+| `enabled` | `boolean` | Whether the policy is active. Disabled policies never sponsor, regardless of dates. |
+| `private` | `boolean` | Private policies require the wallet to pass the policy ID when requesting sponsorship. Public policies apply without one. |
+| `policyId` | `string` | Assigned by InstaGas at creation. Wallets reference it as the sponsorship policy ID for private policies. |
+| `startDate` | `number` | Unix timestamp in milliseconds. Sponsorship starts at this time. |
+| `endDate` | `number` | Unix timestamp in milliseconds. Sponsorship stops at this time. |
+
+### Account
+
+| field | type | description |
+| :--- | :--- | :--- |
+| `totalMax` | `string` (hex wei) | Lifetime sponsorship limit per account. `0x6f05b59d3b20000` is 0.5 ETH. |
+| `maxPerOp` | `string` (hex wei) | Maximum sponsored gas cost for a single UserOperation. `0x5af3107a4000` is 0.0001 ETH. |
+| `rate` | `number` | Number of sponsored UserOperations allowed per `ratePeriod`, per account. |
+| `ratePeriod` | `number` | Rate limit window in seconds. `86400` with `rate: 3` means 3 sponsorships per account per day. |
+
+Amounts are entered in ETH in the dashboard and stored as hex-encoded wei.
+
+### Access
+
+| field | type | description |
+| :--- | :--- | :--- |
+| `whitelistedAccounts` | `{address, label}[]` | Sender addresses eligible for sponsorship. Empty allows all senders. |
+| `whitelistedOrigins` | `{origin, label}[]` | Web origins eligible for sponsorship. Empty allows all origins. Subdomain wildcards are supported, and the scheme is required: `https://*.example.com` is valid, `*.example.com` is not. |
+| `whitelistedIPs` | `{ip, label}[]` | IP addresses eligible for sponsorship. Empty allows all IPs. |
+
+### Transactions
+
+Each entry describes one allowed contract call. Constraints within an entry must all pass for the call to qualify.
+
+| field | type | description |
+| :--- | :--- | :--- |
+| `to` | `string` (address) | The contract the call must target. |
+| `selector` | `string` (4-byte hex) | The function selector the call must invoke. |
+| `abi` | `string` | The ABI fragment of the function, used to decode call parameters for constraint checks. |
+| `params` | `constraint[]` | Constraints on the decoded call parameters. Empty sponsors any call to this function. |
+
+Each parameter constraint:
+
+| field | type | description |
+| :--- | :--- | :--- |
+| `indexes` | `number[]` | Path to the parameter: the top-level argument position, followed by component positions for nested tuples. `[0, 5]` targets the sixth field of the first argument. |
+| `operator` | `string` | One of the operators below. |
+| `value` | `string` | The value the decoded argument is compared against. Token amounts are in the token's smallest unit. |
+
+Supported operators:
+
+| operator | meaning |
+| :--- | :--- |
+| `$eq` | Equals |
+| `$gt` | Greater than |
+| `$gte` | Greater than or equal |
+| `$lt` | Less than |
+| `$lte` | Less than or equal |
+| `$startsWith` | Value prefix match |
+
+The comparison operators apply to numeric parameters. Use `$eq` for addresses and exact matches.

--- a/docs/instagas/6-batch-sponsor-transactions.mdx
+++ b/docs/instagas/6-batch-sponsor-transactions.mdx
@@ -49,7 +49,7 @@ The following apps and wallets support smart capabilities.
 
 |                      App                            | Batching | Sponsor Gas |
 |-----------------------------------------------------|----------|-------------|
-| [PoolTogether Cabana](https://app.cabana.fi/)       | ✅       | ERC-767     |
+| [PoolTogether Cabana](https://app.cabana.fi/)       | ✅       | ERC-7677    |
 | [revoke.cash](https://revoke.cash/)                 | ✅       | ERC-7677    |
 | [Lido](https://lido.fi)                             | ✅       | ✖️          |
 | [Lifi](https://li.fi/)                              | ✅       | ✖️          |
@@ -64,7 +64,6 @@ The following apps and wallets support smart capabilities.
 | [Ethena](https://app.ethena.fi/)                    | ✅       | ✖️          |
 | [Fibrous](https://app.fibrous.finance/)             | ✅       | ✖️          |
 | [PWN](https://app.pwn.xyz/)                         | ✅       | ✖️          |
-| [Relay](https://relay.link/bridge)                  | ✅       | ✖️          |
 | [Relay](https://relay.link/bridge)                  | ✅       | ✖️          |
 
 ## Reference Example
@@ -326,8 +325,8 @@ Requests that the wallet deliver a group of function calls on-chain from the use
       "paymasterService": {
           "url": "https://...",
           "optional": true,
-          "context" {
-            "sponsorshipPolicyId": "123",
+          "context": {
+            "sponsorshipPolicyId": "123"
           }
         }
       }


### PR DESCRIPTION
## What

InstaGas gas policies were documented only as dashboard screenshots and illustrative prose, so an AI agent (or a developer planning a config) had nothing precise to work from. This adds a **Policy Object Reference** section to the gas policies page:

- Complete JSON shape of a policy across its four rule groups
- Typed field tables with explicit units: amounts are hex-encoded wei, rate periods are seconds, active dates are millisecond timestamps
- The parameter constraint grammar formalized: `indexes` paths for nested tuple parameters, and the six operators (`$eq`, `$gt`, `$gte`, `$lt`, `$lte`, `$startsWith`)
- Framing is dashboard-first: this documents the object the dashboard edits, it does not claim a public policy API exists

Field names, types, and units were sourced from the dashboard's policy model, not invented. Also fixes three bugs on the batch-sponsor page that would poison copy-paste: the `ERC-767` typo, a duplicated Relay row, and malformed JSON in the capabilities example (`"context" {`).

## Needs your confirmation before merge

Two semantics I inferred rather than verified: (1) whether multiple transaction rules evaluate as an OR list over calls in a batch, and (2) which parameter types `$startsWith` applies to. Both are stated conservatively in the text; correct me if either is off.

## Verification

`yarn build` passes with no broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new policy object reference section with a JSON example and schema details for policy settings, including general, account, access, and transaction constraints.
  * Updated the batch sponsor transactions guide to correct an EIP reference, remove a duplicated table entry, and improve JSON example formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->