### PR TITLE
docs: add Reliability & Monitoring page

### DIFF
--- a/docs/wallet/api/reliability.mdx
+++ b/docs/wallet/api/reliability.mdx
@@ -1,0 +1,29 @@
+---
+slug: reliability
+title: Reliability & Monitoring
+description: How Candide maintains 99.9% uptime across the Bundler and Paymaster, on every supported chain.
+image: /img/posters/voltaire-meta.png
+authors: [marc]
+---
+
+Smart wallet infrastructure has one job: be there when a transaction needs to go through. A stuck transaction isn't an inconvenience, it's a stuck user, a failed payment, a support ticket you can't explain.
+
+## How we verify liveness
+
+We don't rely on node health checks alone. Every minute, on every chain we support, we execute a real signed transaction end to end. This confirms the full path works: RPC connectivity, bundler availability, and finality, not just that a server returned `200 OK`.
+
+## RPC redundancy
+
+Every chain we support is backed by multiple independent RPC providers. If one degrades or goes down, traffic fails over automatically. This happens without operator intervention and without a visible interruption to requests in flight.
+
+## Monitoring built for chains, not servers
+
+Standard uptime tooling checks if an endpoint responds. It won't catch a stuck mempool, a reorg, a gas spike, or a nonce gap, the failure modes that actually cause stuck transactions. We built our own monitoring for these cases specifically, so an issue is caught and alerted on before it reaches a production wallet.
+
+## Live status
+
+Current and historical uptime is public at [status.candide.dev](https://status.candide.dev).
+
+## What we don't publish
+
+We don't disclose our specific RPC providers, alert thresholds, or failover logic publicly. If you're doing vendor diligence and need detail beyond what's here, [contact us](https://www.candide.dev/contact) and we'll walk through it under NDA.

--- a/docs/wallet/api/reliability.mdx
+++ b/docs/wallet/api/reliability.mdx
@@ -1,7 +1,7 @@
 ---
 slug: reliability
 title: Reliability & Monitoring
-description: How Candide maintains 99.9% uptime across the Bundler and Paymaster, on every supported chain.
+description: How Candide keeps the Bundler and Paymaster available on every supported chain, and the SLA that applies to each plan.
 image: /img/posters/voltaire-meta.png
 authors: [marc]
 ---
@@ -10,20 +10,27 @@ Smart wallet infrastructure has one job: be there when a transaction needs to go
 
 ## How we verify liveness
 
-We don't rely on node health checks alone. Every minute, on every chain we support, we execute a real signed transaction end to end. This confirms the full path works: RPC connectivity, bundler availability, and finality, not just that a server returned `200 OK`.
+Every minute, on every chain we support, we execute a real signed transaction end to end. This confirms the full path works: RPC connectivity, bundler availability, and finality. A node health check only confirms a server responded, it says nothing about whether a transaction actually landed.
 
 ## RPC redundancy
 
-Every chain we support is backed by multiple independent RPC providers. If one degrades or goes down, traffic fails over automatically. This happens without operator intervention and without a visible interruption to requests in flight.
+Every chain we support runs behind multiple independent RPC providers. If one degrades or goes down, traffic fails over automatically, without operator intervention and without a visible interruption to requests in flight.
 
-## Monitoring built for chains, not servers
+## Monitoring built for chains
 
-Standard uptime tooling checks if an endpoint responds. It won't catch a stuck mempool, a reorg, a gas spike, or a nonce gap, the failure modes that actually cause stuck transactions. We built our own monitoring for these cases specifically, so an issue is caught and alerted on before it reaches a production wallet.
+Chain failures look different from server failures: stuck mempools, reorgs, gas spikes, nonce gaps. We built monitoring for these specifically. An issue triggers an alert before it reaches a production wallet.
+
+## SLA by plan
+
+| Plan | SLA |
+|------|-----|
+| Starter | No SLA |
+| Launch Prod | No SLA |
+| Grow | 99% uptime |
+| Enterprise | 99.9% uptime, or as specified in contract |
+
+Full terms, downtime definition, and service credits are in our [Terms of Service](https://www.candide.dev/legal/tos).
 
 ## Live status
 
 Current and historical uptime is public at [status.candide.dev](https://status.candide.dev).
-
-## What we don't publish
-
-We don't disclose our specific RPC providers, alert thresholds, or failover logic publicly. If you're doing vendor diligence and need detail beyond what's here, [contact us](https://www.candide.dev/contact) and we'll walk through it under NDA.

--- a/docs/wallet/intro.mdx
+++ b/docs/wallet/intro.mdx
@@ -109,7 +109,7 @@ Access [Candide's Dashboard](https://dashboard.candide.dev) to get API keys and 
 
 ## Chains Supported
 
-Candide is available on all major EVM equivalent networks, plus Solana through the [Solana Paymaster](/wallet/guides/pay-gas-in-usdt-solana/). Reach out if you need a network added.
+Candide is available on all major EVM equivalent networks, plus Solana through the [Solana Paymaster](/wallet/guides/pay-gas-in-usdt-solana/). Reach out if you need a network added. Every chain runs the same [reliability guarantees](/wallet/api/reliability/): 99.9% uptime SLA on Enterprise, verified every minute.
 
 import { NetworkList } from "/src/components/NetworkList";
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -66,6 +66,11 @@ const sidebars = {
           id: "wallet/api/public-endpoints",
           label: "Public Endpoints"
         },
+        {
+          type: "doc",
+          id: "wallet/api/reliability",
+          label: "Reliability & Monitoring"
+        },
       ],
     },
     {

--- a/sidebars.js
+++ b/sidebars.js
@@ -66,11 +66,6 @@ const sidebars = {
           id: "wallet/api/public-endpoints",
           label: "Public Endpoints"
         },
-        {
-          type: "doc",
-          id: "wallet/api/reliability",
-          label: "Reliability & Monitoring"
-        },
       ],
     },
     {
@@ -688,6 +683,11 @@ const sidebars = {
           type: "doc",
           id: "wallet/technical-reference/deployments",
           label: "Deployment Addresses"
+        },
+        {
+          type: "doc",
+          id: "wallet/api/reliability",
+          label: "Reliability & Monitoring"
         },
       ],
     },


### PR DESCRIPTION
## Summary
- New page under Bundler & Paymaster (`wallet/api/reliability`) explaining how Candide maintains 99.9% uptime: per-chain synthetic transactions every minute, redundant RPC providers with automatic failover, and custom chain-aware monitoring/alerting.
- Links to the public status page (status.candide.dev) as the verifiable source of truth.
- Companion to the shorter trust-section blurb going on the landing page (candidelabs/landing-page#18).

Deliberately excludes specific RPC provider names, alert thresholds, and failover order, closes with a pointer to contact for diligence requests under NDA instead.

## Test plan
- [x] `docusaurus build` succeeds, page and sidebar entry render
- [ ] Spot check sidebar placement/label in deploy preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Wallet API page covering reliability and monitoring.
  * Documented liveness verification, multi-provider RPC redundancy with automatic failover, and chain-specific failure monitoring (e.g., mempool stalls, reorgs, gas spikes, nonce gaps).
  * Added public uptime availability details and a link to the status page.
  * Updated the Wallet documentation navigation to include the new “Reliability & Monitoring” section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->