### PR TITLE
docs: document gas policy management API

### DIFF
--- a/docs/instagas/1-overview.mdx
+++ b/docs/instagas/1-overview.mdx
@@ -1,13 +1,13 @@
 ---
-title: InstaGas Quickstart | No-Code Gas Sponsorship
-description: A No-Code Gas Sponsorship Paymaster for dapps to define gas policies to directly sponsor gas for Smart Wallets end-users
+title: InstaGas Quickstart | Gas Sponsorship Policies
+description: Create gas policies from the Candide Dashboard or Platform API to sponsor Smart Wallet users securely.
 keywords: [gas sponsorship, paymaster, eip-7702, erc-4337, gas station, gas policies, gas abstraction]
 image: /img/posters/paymaster-meta.png
 ---
 
 # InstaGas
 
-InstaGas is a **no-code** platform enabling you to sponsor gas fees for end users by creating customized gas policies tailored to specific smart contracts and use cases.
+InstaGas lets you sponsor gas fees for end users with customized policies tailored to specific smart contracts and use cases. Configure policies interactively in the Dashboard or automate them with the [Platform API](/platform/overview).
 
 ![candide-instagas-logo](/img/logo/instagas-logo.png)
 
@@ -26,7 +26,7 @@ For more examples, visit our [Use Cases Categories](/instagas/usecases) page.
 
 ## How It Works
 
-1. Set up a gas policy on the [dashboard](https://dashboard.candide.dev)
+1. Set up a gas policy in the [Dashboard](https://dashboard.candide.dev) or with the [Gas Policy API](/platform/gas-policy-api)
 2. Make the policy `public` by toggling the privacy rule in General Rules settings
 3. Customize your policy with rules aligned with your app's needs
 4. Top up your team balance and transfer funds to the policy
@@ -46,6 +46,8 @@ InstaGas provides customizable rules for gas policies, categorized into four sec
 4. Transaction Rules
 
 Learn more about [Gas Policies and Rules](/instagas/gas-policies) on the next page.
+
+To create, update, or delete policies programmatically, follow the [Platform API quickstart](/platform/overview).
 
 ## Support
 

--- a/docs/instagas/2-gas-policies.mdx
+++ b/docs/instagas/2-gas-policies.mdx
@@ -1,6 +1,6 @@
 ---
 title: InstaGas Gas Policies
-description: A No-Code Gas Sponsorship Paymaster for dapps to define gas policies to directly sponsor gas for Smart Wallets end-users
+description: Understand the general, account, access, and transaction rules available to Candide gas sponsorship policies.
 keywords: [InstaGas, gas policy, gas sponsorship, smart contracts, eip-7702]
 image: /img/posters/paymaster-meta.png
 ---
@@ -87,48 +87,47 @@ For each function, you can specify a list of parameters, and each parameter can 
 
 By specifying these constraints, you can control the behavior of the swap transaction and ensure that it is executed according to your requirements. For instance, you can ensure that the swap transaction only occurs if the amount being swapped is greater than 350, and if the tokens being swapped are USDT and WETH.
 
-## Policy Object Reference
+## Policy configuration example
 
-Policies are created and edited in the [dashboard](https://dashboard.candide.dev). This section defines the underlying policy object precisely, so you can plan a configuration before opening the dashboard, review an existing one, or have an AI agent draft the exact values to enter.
+Policies can be created and edited in the [Dashboard](https://dashboard.candide.dev) or through the [Platform API](/platform/overview). The example below is a policy creation body using the public API field names.
+
+For request validation, update semantics, and response fields, use the [Gas Policy API reference](/platform/gas-policy-api) as the canonical source.
 
 ```json
 {
   "name": "Onboarding sponsorship",
   "chainId": 10,
-  "generalPolicy": {
+  "general": {
     "enabled": true,
     "private": false,
-    "policyId": "175c73...",
     "startDate": 1751500800000,
     "endDate": 1754179200000
   },
-  "accountPolicy": {
+  "accountRules": {
     "totalMax": "0x6f05b59d3b20000",
     "maxPerOp": "0x5af3107a4000",
     "rate": 3,
     "ratePeriod": 86400
   },
-  "accessPolicy": {
-    "whitelistedAccounts": [
-      { "address": "0xA1b2C3d4E5f6A7b8C9d0E1f2A3b4C5d6E7f8A9b0", "label": "Beta tester" }
+  "accessRules": {
+    "accounts": [
+      { "value": "0xA1b2C3d4E5f6A7b8C9d0E1f2A3b4C5d6E7f8A9b0", "label": "Beta tester" }
     ],
-    "whitelistedOrigins": [
-      { "origin": "https://*.example.com", "label": "Our app" }
+    "origins": [
+      { "value": "https://*.example.com", "label": "Our app" }
     ],
-    "whitelistedIPs": []
+    "ips": []
   },
-  "transactionsPolicy": {
-    "transactions": [
-      {
-        "to": "0xE592427A0AEce92De3Edee1F18E0157C05861564",
-        "selector": "0x414bf389",
-        "abi": "{\"name\": \"exactInputSingle\", \"type\": \"function\", ...}",
-        "params": [
-          { "indexes": [0, 5], "operator": "$gte", "value": "1000000" }
-        ]
-      }
-    ]
-  }
+  "transactions": [
+    {
+      "to": "0xE592427A0AEce92De3Edee1F18E0157C05861564",
+      "selector": "0x414bf389",
+      "abi": "{\"name\": \"exactInputSingle\", \"type\": \"function\", ...}",
+      "parameters": [
+        { "index": "0;5", "operator": "$gte", "value": "1000000" }
+      ]
+    }
+  ]
 }
 ```
 
@@ -138,7 +137,7 @@ Policies are created and edited in the [dashboard](https://dashboard.candide.dev
 | :--- | :--- | :--- |
 | `enabled` | `boolean` | Whether the policy is active. Disabled policies never sponsor, regardless of dates. |
 | `private` | `boolean` | Private policies require the wallet to pass the policy ID when requesting sponsorship. Public policies apply without one. |
-| `policyId` | `string` | Assigned by InstaGas at creation. Wallets reference it as the sponsorship policy ID for private policies. |
+| `sponsorshipPolicyId` | `string` | Assigned by InstaGas at creation. Wallets reference it as the sponsorship policy ID for private policies. |
 | `startDate` | `number` | Unix timestamp in milliseconds. Sponsorship starts at this time. |
 | `endDate` | `number` | Unix timestamp in milliseconds. Sponsorship stops at this time. |
 
@@ -157,9 +156,9 @@ Amounts are entered in ETH in the dashboard and stored as hex-encoded wei.
 
 | field | type | description |
 | :--- | :--- | :--- |
-| `whitelistedAccounts` | `{address, label}[]` | Sender addresses eligible for sponsorship. Empty allows all senders. |
-| `whitelistedOrigins` | `{origin, label}[]` | Web origins eligible for sponsorship. Empty allows all origins. Subdomain wildcards are supported, and the scheme is required: `https://*.example.com` is valid, `*.example.com` is not. |
-| `whitelistedIPs` | `{ip, label}[]` | IP addresses eligible for sponsorship. Empty allows all IPs. |
+| `accounts` | `{value, label}[]` | Sender addresses eligible for sponsorship. Empty allows all senders. |
+| `origins` | `{value, label}[]` | Web origins eligible for sponsorship. Empty allows all origins. Subdomain wildcards are supported, and the scheme is required: `https://*.example.com` is valid, `*.example.com` is not. |
+| `ips` | `{value, label}[]` | IP addresses eligible for sponsorship. Empty allows all IPs. |
 
 ### Transactions
 
@@ -170,13 +169,13 @@ Each entry describes one allowed contract call. Constraints within an entry must
 | `to` | `string` (address) | The contract the call must target. |
 | `selector` | `string` (4-byte hex) | The function selector the call must invoke. |
 | `abi` | `string` | The ABI fragment of the function, used to decode call parameters for constraint checks. |
-| `params` | `constraint[]` | Constraints on the decoded call parameters. Empty sponsors any call to this function. |
+| `parameters` | `constraint[]` | Constraints on the decoded call parameters. Empty sponsors any call to this function. |
 
 Each parameter constraint:
 
 | field | type | description |
 | :--- | :--- | :--- |
-| `indexes` | `number[]` | Path to the parameter: the top-level argument position, followed by component positions for nested tuples. `[0, 5]` targets the sixth field of the first argument. |
+| `index` | `string` | Argument index. Use semicolons for nested tuples: `0;5` targets the sixth field of the first argument. |
 | `operator` | `string` | One of the operators below. |
 | `value` | `string` | The value the decoded argument is compared against. Token amounts are in the token's smallest unit. |
 

--- a/docs/platform/gas-policy-api.mdx
+++ b/docs/platform/gas-policy-api.mdx
@@ -1,0 +1,486 @@
+---
+title: Gas Policy Management API Reference
+description: REST API reference for creating and managing team-scoped Candide gas policies, access rules, and allowed transactions.
+keywords: [gas policy api, platform api, rest api, gas sponsorship, openapi]
+image: /img/posters/paymaster-meta.png
+---
+
+# Gas Policy Management API
+
+Use this team-scoped REST API to create, inspect, update, and delete Candide gas policies programmatically.
+
+- Base URL: `https://platform-api.candide.dev`
+- Content type: `application/json`
+- Authentication: `Authorization: Bearer <management_key>`
+- OpenAPI: [download the complete OpenAPI 3.1 specification](/openapi/platform-api.yaml)
+
+Management keys begin with `mk_` and belong to one team. Keep them in trusted server-side environments. See the [Platform API overview](/platform/overview) for a safe first integration.
+
+## Endpoint summary
+
+| Method | Path | Required scope | Success |
+| :--- | :--- | :--- | :--- |
+| `GET` | `/v1/me` | Valid management key | `200` |
+| `GET` | `/v1/gas-policies` | `gas-policies:read` | `200` |
+| `POST` | `/v1/gas-policies` | `gas-policies:write` | `201` |
+| `GET` | `/v1/gas-policies/{policyId}` | `gas-policies:read` | `200` |
+| `PATCH` | `/v1/gas-policies/{policyId}` | `gas-policies:write` | `200` |
+| `DELETE` | `/v1/gas-policies/{policyId}` | `gas-policies:write` | `200` |
+| `PATCH` | `/v1/gas-policies/{policyId}/access-rules` | `gas-policies:write` | `200` |
+| `PUT` | `/v1/gas-policies/{policyId}/transactions` | `gas-policies:write` | `200` |
+| `POST` | `/v1/gas-policies/{policyId}/transactions` | `gas-policies:write` | `201` |
+| `DELETE` | `/v1/gas-policies/{policyId}/transactions/{transactionId}` | `gas-policies:write` | `200` |
+
+## Conventions
+
+- `policyId` and `transactionId` are opaque strings.
+- Policy list pages use a zero-based `page` index.
+- Dates are Unix timestamps in milliseconds.
+- `ratePeriod` is measured in seconds.
+- Gas spending limits and billing amounts are hexadecimal wei strings.
+- Unknown, deleted, and cross-team resources return `404`.
+- A validation error returns `422` with field paths in `error.details`.
+
+## Identity
+
+### Get management key information
+
+`GET /v1/me`
+
+Returns the team and scopes associated with the calling key.
+
+```bash
+curl --request GET \
+  --url https://platform-api.candide.dev/v1/me \
+  --header "Authorization: Bearer $CANDIDE_MANAGEMENT_KEY"
+```
+
+```json
+{
+  "keyId": "key_123",
+  "teamId": "team_123",
+  "scopes": ["gas-policies:read", "gas-policies:write"]
+}
+```
+
+Possible scopes are `gas-policies:read` and `gas-policies:write`. This endpoint returns `401` for a missing or invalid key and `500` for an unexpected server error.
+
+## Gas policies
+
+### List gas policies
+
+`GET /v1/gas-policies`
+
+| Query parameter | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `chainId` | integer | — | Return policies for one chain ID |
+| `enabled` | boolean | — | Return only enabled or disabled policies |
+| `page` | non-negative integer | `0` | Zero-based page index |
+| `pageSize` | integer | `25` | One of `10`, `25`, `50`, or `100` |
+
+```bash
+curl --request GET \
+  --url "https://platform-api.candide.dev/v1/gas-policies?chainId=11155111&enabled=false&page=0&pageSize=25" \
+  --header "Authorization: Bearer $CANDIDE_MANAGEMENT_KEY"
+```
+
+```json
+{
+  "items": [
+    {
+      "id": "policy_123",
+      "name": "Onboarding sponsorship",
+      "chainId": 11155111,
+      "enabled": false,
+      "private": true,
+      "createdAt": 1784678400000,
+      "billing": {
+        "currency": "ETH",
+        "balance": "0x0",
+        "lockedBalance": "0x0",
+        "available": "0x0"
+      }
+    }
+  ],
+  "total": 1,
+  "page": 0,
+  "pageSize": 25
+}
+```
+
+Returns `400` for invalid filters or pagination and `403` when the key lacks `gas-policies:read`.
+
+### Create a gas policy
+
+`POST /v1/gas-policies`
+
+| Field | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `name` | string | Yes | Display name, 3–50 characters |
+| `chainId` | integer | Yes | Chain enabled for the calling team |
+| `general` | [General input](#general-input) | No | General policy settings |
+| `accountRules` | [Account rules input](#account-rules-input) | No | Per-account limits |
+| `accessRules` | [Access rules input](#access-rules-input) | No | Initial account, origin, and IP allowlists |
+| `transactions` | [Transaction input](#transaction-input)[] | No | Initial ordered transaction list |
+
+```bash
+curl --request POST \
+  --url https://platform-api.candide.dev/v1/gas-policies \
+  --header "Authorization: Bearer $CANDIDE_MANAGEMENT_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "name": "Onboarding sponsorship",
+    "chainId": 11155111,
+    "general": {
+      "enabled": false,
+      "private": true
+    },
+    "accountRules": {
+      "rate": 3,
+      "ratePeriod": 86400,
+      "totalMax": "0x6f05b59d3b20000",
+      "maxPerOp": "0x5af3107a4000"
+    },
+    "accessRules": {
+      "origins": [
+        {
+          "value": "https://app.example.com",
+          "label": "Production app"
+        }
+      ]
+    }
+  }'
+```
+
+Returns `201` with a complete [policy detail](#policy-detail). A plan limit on mainnet policies returns `403`; invalid field values return `422`.
+
+### Get a gas policy
+
+`GET /v1/gas-policies/{policyId}`
+
+```bash
+curl --request GET \
+  --url https://platform-api.candide.dev/v1/gas-policies/POLICY_ID \
+  --header "Authorization: Bearer $CANDIDE_MANAGEMENT_KEY"
+```
+
+Returns `200` with a [policy detail](#policy-detail), `403` without the read scope, or `404` when the policy is unavailable to the calling team.
+
+### Update a gas policy
+
+`PATCH /v1/gas-policies/{policyId}`
+
+Provide at least one of `name`, `general`, `accountRules`, or `accessRules`. Omitted fields remain unchanged. Fields inside `general` and `accountRules` are merged over their current values. Each whitelist included in `accessRules` replaces that complete whitelist.
+
+```bash
+curl --request PATCH \
+  --url https://platform-api.candide.dev/v1/gas-policies/POLICY_ID \
+  --header "Authorization: Bearer $CANDIDE_MANAGEMENT_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "name": "Production onboarding",
+    "general": {
+      "enabled": true
+    },
+    "accountRules": {
+      "rate": 5,
+      "ratePeriod": 86400
+    }
+  }'
+```
+
+Returns `200` with the updated [policy detail](#policy-detail). Use the dedicated access-rules endpoint for additive changes and the transactions endpoints for transaction changes.
+
+### Delete a gas policy
+
+`DELETE /v1/gas-policies/{policyId}`
+
+```bash
+curl --request DELETE \
+  --url https://platform-api.candide.dev/v1/gas-policies/POLICY_ID \
+  --header "Authorization: Bearer $CANDIDE_MANAGEMENT_KEY"
+```
+
+```json
+{
+  "id": "policy_123",
+  "deleted": true
+}
+```
+
+## Access rules
+
+### Update access rules
+
+`PATCH /v1/gas-policies/{policyId}/access-rules`
+
+Provide at least one of `accounts`, `origins`, or `ips`. Each provided rule accepts one operation mode:
+
+| Mode | Behavior |
+| :--- | :--- |
+| `add` and/or `remove` | Modify the existing entries. Both are idempotent; removal runs first |
+| `set` | Replace the complete entry list. An empty list allows all values |
+| `allowAll: true` | Reset the rule to allow all values |
+
+Do not combine `set` or `allowAll` with the `add`/`remove` group for the same rule.
+
+```bash
+curl --request PATCH \
+  --url https://platform-api.candide.dev/v1/gas-policies/POLICY_ID/access-rules \
+  --header "Authorization: Bearer $CANDIDE_MANAGEMENT_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "accounts": {
+      "remove": ["0x1111111111111111111111111111111111111111"],
+      "add": [
+        {
+          "value": "0x2222222222222222222222222222222222222222",
+          "label": "New beta tester"
+        }
+      ]
+    },
+    "origins": {
+      "set": ["https://app.example.com"]
+    }
+  }'
+```
+
+Returns `200` with the updated [policy detail](#policy-detail).
+
+## Transactions
+
+Transaction entries are ordered. Each input must contain `to`, `abi`, `selector`, and `parameters`.
+
+### Replace all transactions
+
+`PUT /v1/gas-policies/{policyId}/transactions`
+
+Replaces the complete ordered transaction list. Pass an empty array to set the list to empty.
+
+```bash
+curl --request PUT \
+  --url https://platform-api.candide.dev/v1/gas-policies/POLICY_ID/transactions \
+  --header "Authorization: Bearer $CANDIDE_MANAGEMENT_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "transactions": [
+      {
+        "to": "0x1111111111111111111111111111111111111111",
+        "abi": "{\"type\":\"function\",\"name\":\"transfer\",\"inputs\":[{\"name\":\"to\",\"type\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\"}]}",
+        "selector": "0xa9059cbb",
+        "parameters": [
+          {
+            "index": "1",
+            "operator": "$lte",
+            "value": "1000000"
+          }
+        ]
+      }
+    ]
+  }'
+```
+
+Returns `200` with the updated [policy detail](#policy-detail).
+
+### Append a transaction
+
+`POST /v1/gas-policies/{policyId}/transactions`
+
+The request body is one [transaction input](#transaction-input).
+
+```bash
+curl --request POST \
+  --url https://platform-api.candide.dev/v1/gas-policies/POLICY_ID/transactions \
+  --header "Authorization: Bearer $CANDIDE_MANAGEMENT_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "to": "${userop.sender}",
+    "abi": "{\"type\":\"function\",\"name\":\"execute\",\"inputs\":[]}",
+    "selector": "0x61461954",
+    "parameters": []
+  }'
+```
+
+```json
+{
+  "transactionId": "transaction_123",
+  "policy": {
+    "id": "policy_123",
+    "name": "Onboarding sponsorship",
+    "chainId": 11155111,
+    "createdAt": 1784678400000,
+    "general": {
+      "enabled": false,
+      "private": true,
+      "sponsorshipPolicyId": "sp_123",
+      "startDate": 1784678400000,
+      "endDate": 1787356800000
+    },
+    "accountRules": {
+      "rate": 3,
+      "ratePeriod": 86400,
+      "totalMax": "0x6f05b59d3b20000",
+      "maxPerOp": "0x5af3107a4000"
+    },
+    "accessRules": {
+      "accounts": {"allowAll": true, "entries": []},
+      "origins": {"allowAll": false, "entries": [{"value": "https://app.example.com", "label": "Production app"}]},
+      "ips": {"allowAll": true, "entries": []}
+    },
+    "transactions": [
+      {
+        "id": "transaction_123",
+        "to": "${userop.sender}",
+        "contractName": "-",
+        "selector": "0x61461954",
+        "abi": "{\"type\":\"function\",\"name\":\"execute\",\"inputs\":[]}",
+        "parameters": []
+      }
+    ],
+    "billing": {
+      "currency": "ETH",
+      "balance": "0x0",
+      "lockedBalance": "0x0",
+      "available": "0x0"
+    }
+  }
+}
+```
+
+### Remove a transaction
+
+`DELETE /v1/gas-policies/{policyId}/transactions/{transactionId}`
+
+```bash
+curl --request DELETE \
+  --url https://platform-api.candide.dev/v1/gas-policies/POLICY_ID/transactions/TRANSACTION_ID \
+  --header "Authorization: Bearer $CANDIDE_MANAGEMENT_KEY"
+```
+
+Returns `200` with the updated policy. A transaction that is not on the policy returns `404`.
+
+## Input models
+
+### General input
+
+All fields are optional and merge over the current general settings.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `enabled` | boolean | Whether the policy is active |
+| `private` | boolean | Require the sponsorship policy ID to match |
+| `startDate` | integer | Active-from time in milliseconds; cannot move more than one day into the past |
+| `endDate` | integer | Active-until time in milliseconds; must be after `startDate` |
+
+### Account rules input
+
+All fields are optional and merge over the current account rules.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `rate` | integer | Positive sponsorship limit, or `-1` to disable rate limiting |
+| `ratePeriod` | integer | Required unless `rate` is `-1`; allowed values are `3600`, `43200`, `86400`, `604800`, `1296000`, `2592000`, and `3153600000` |
+| `totalMax` | string | Maximum total gas spending per account, in hex wei |
+| `maxPerOp` | string | Maximum gas spending for one UserOperation, in hex wei |
+
+### Access rules input
+
+`accounts`, `origins`, and `ips` each accept an array of strings or `{"value": string, "label": string}` objects. A label is optional. An empty array means allow all.
+
+- Account values are account addresses.
+- Origin values are HTTPS origins.
+- IP values are IPv4 addresses.
+
+### Transaction input
+
+| Field | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `to` | string | Yes | Target contract address or the literal `"${userop.sender}"` |
+| `abi` | string | Yes | JSON ABI fragment containing the function |
+| `selector` | string | Yes | Four-byte function selector with eight hex digits |
+| `parameters` | transaction parameter[] | Yes | Argument constraints; may be empty |
+
+Each transaction parameter has:
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `index` | string | Argument index. Use semicolons to descend into tuples, for example `"0;3"` |
+| `operator` | string | `$eq`, `$gt`, `$gte`, `$lt`, `$lte`, or `$startsWith` |
+| `value` | string | Value to compare against |
+
+## Response models
+
+### Policy detail
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `id` | string | Policy ID |
+| `name` | string | Display name |
+| `chainId` | integer | Sponsored chain |
+| `createdAt` | integer | Creation time in milliseconds since Unix epoch |
+| `general` | object | `enabled`, `private`, `sponsorshipPolicyId`, `startDate`, and `endDate` |
+| `accountRules` | object | `rate`, `ratePeriod`, `totalMax`, and `maxPerOp` |
+| `accessRules` | object | Account, origin, and IP access-rule states |
+| `transactions` | transaction[] | Ordered allowed transactions |
+| `billing` | object | Policy funding information |
+
+Each returned access rule contains `allowAll` and `entries`. Each entry contains `value` and `label`; the label defaults to a dash.
+
+Each returned transaction contains its `id`, `to`, resolved `contractName` (or a dash), `selector`, `abi`, and `parameters`.
+
+Billing fields are hexadecimal wei strings:
+
+| Field | Description |
+| :--- | :--- |
+| `currency` | Native token symbol for the policy's chain |
+| `balance` | Total policy funds |
+| `lockedBalance` | Funds reserved for in-flight operations |
+| `available` | Balance minus locked balance |
+
+## Errors
+
+Every error response uses this envelope:
+
+```json
+{
+  "error": {
+    "code": "validation_error",
+    "message": "Request validation failed.",
+    "details": {
+      "accountRules.maxPerOp": "must be a valid non-negative hex amount"
+    }
+  }
+}
+```
+
+`details` is present on validation errors and maps field paths to reasons.
+
+| Status | Code | Meaning |
+| :--- | :--- | :--- |
+| `400` | `bad_request` | Malformed JSON, query value, unavailable team chain, or empty update |
+| `401` | `unauthorized` | Missing, malformed, or invalid management key |
+| `403` | `forbidden` | Missing scope or team plan policy limit |
+| `404` | `not_found` | Unknown, deleted, or cross-team policy or transaction |
+| `422` | `validation_error` | One or more request fields failed validation |
+| `500` | `internal_error` | Unexpected server error |
+
+Documented messages include:
+
+- `Request body is not valid JSON.`
+- `chainId must be an integer.`
+- `enabled must be 'true' or 'false'.`
+- `page must be a non-negative integer.`
+- `pageSize must be one of 10, 25, 50, 100.`
+- `Chain {chainId} is not available for this team.`
+- `Provide at least one field to update: name, general, accountRules, accessRules.`
+- `Provide at least one of: accounts, origins, ips.`
+- `Missing or malformed Authorization header. Use 'Authorization: Bearer <management_key>'.`
+- `Missing management key.`
+- `Invalid management key.`
+- `This management key is missing the required scope: {scope}`
+- `Your plan does not allow more than {n} gas policies on mainnets. Upgrade your plan for more.`
+- `Gas policy not found.`
+- `Transaction {transactionId} not found on this policy.`
+- `The requested endpoint does not exist.`
+- `Request validation failed.`
+- `An unexpected error occurred.`

--- a/docs/platform/overview.mdx
+++ b/docs/platform/overview.mdx
@@ -1,0 +1,143 @@
+---
+title: Platform API
+description: Manage Candide gas sponsorship policies programmatically with a team-scoped REST API.
+keywords: [platform api, gas policy api, gas sponsorship, management key, automation]
+image: /img/posters/paymaster-meta.png
+---
+
+# Platform API
+
+The Platform API lets you create and maintain Candide gas policies from backend services, deployment scripts, and internal tools. It provides the same policy-management capabilities as the Candide Dashboard, without requiring someone to configure every policy manually.
+
+Use it when policy configuration is part of your application's workflow—for example, provisioning a policy for each customer, updating allowlists from an admin service, or keeping policy configuration in sync across environments.
+
+## Choose the right interface
+
+| Interface | Use it for |
+| :--- | :--- |
+| [Dashboard](https://dashboard.candide.dev) | Creating and reviewing policies interactively |
+| Platform API | Creating, reading, updating, and deleting policies from trusted server-side code |
+| [Paymaster API](/wallet/paymaster/rpc-methods) | Requesting sponsorship for a UserOperation at runtime |
+
+The Platform API is a control-plane API: it configures which operations Candide may sponsor. It does not submit or sponsor UserOperations itself.
+
+## Base URL
+
+```text
+https://platform-api.candide.dev
+```
+
+All routes in the current version start with `/v1`.
+
+## Authentication
+
+Create a team management key in the [Dashboard](https://dashboard.candide.dev), grant only the scopes your integration needs, and send it as a bearer token:
+
+```http
+Authorization: Bearer mk_...
+```
+
+| Scope | Allows |
+| :--- | :--- |
+| `gas-policies:read` | List and fetch gas policies |
+| `gas-policies:write` | Create, update, and delete gas policies |
+
+Every request is scoped to the team that owns the key. A policy belonging to another team is treated as not found.
+
+:::danger Keep management keys on the server
+A management key can change sponsorship rules and must never be embedded in browser code, mobile applications, public repositories, or logs. It is separate from the API key used in a Bundler or Paymaster endpoint.
+:::
+
+## Quickstart
+
+Set your management key in the shell. Do not commit it to source control:
+
+```bash
+export CANDIDE_MANAGEMENT_KEY="mk_..."
+```
+
+### 1. Verify the key
+
+```bash
+curl --request GET \
+  --url https://platform-api.candide.dev/v1/me \
+  --header "Authorization: Bearer $CANDIDE_MANAGEMENT_KEY"
+```
+
+The response identifies the key's team and granted scopes:
+
+```json
+{
+  "keyId": "key_123",
+  "teamId": "team_123",
+  "scopes": ["gas-policies:read", "gas-policies:write"]
+}
+```
+
+### 2. Create a policy
+
+Start with the policy disabled and private. Add and review the necessary account, access, and transaction restrictions before enabling it.
+
+```bash
+curl --request POST \
+  --url https://platform-api.candide.dev/v1/gas-policies \
+  --header "Authorization: Bearer $CANDIDE_MANAGEMENT_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "name": "Onboarding sponsorship",
+    "chainId": 11155111,
+    "general": {
+      "enabled": false,
+      "private": true
+    },
+    "accountRules": {
+      "rate": 3,
+      "ratePeriod": 86400,
+      "totalMax": "0x6f05b59d3b20000",
+      "maxPerOp": "0x5af3107a4000"
+    }
+  }'
+```
+
+The API returns the complete policy with status `201 Created`. Save its `id` for management calls. For a private policy, use `general.sponsorshipPolicyId` when requesting sponsorship from the Paymaster API.
+
+### 3. Add restrictions
+
+Use the dedicated endpoints when you need precise list operations:
+
+- `PATCH /v1/gas-policies/{policyId}/access-rules` adds, removes, replaces, or resets access allowlists.
+- `POST /v1/gas-policies/{policyId}/transactions` appends one allowed transaction.
+- `PUT /v1/gas-policies/{policyId}/transactions` replaces the complete ordered transaction list.
+- `DELETE /v1/gas-policies/{policyId}/transactions/{transactionId}` removes one transaction.
+
+An empty account, origin, or IP list means **allow all values for that rule**. Review empty lists carefully before activating a policy.
+
+See the [policy rules overview](/instagas/gas-policies) for the purpose of each rule and the [Gas Policy API reference](/platform/gas-policy-api) for exact request formats.
+
+### 4. Enable the policy
+
+After reviewing the policy, enable it with a partial update:
+
+```bash
+curl --request PATCH \
+  --url https://platform-api.candide.dev/v1/gas-policies/POLICY_ID \
+  --header "Authorization: Bearer $CANDIDE_MANAGEMENT_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{"general":{"enabled":true}}'
+```
+
+Omitted fields remain unchanged.
+
+## Automation guidance
+
+- Call `GET /v1/me` during setup to fail early when a key has the wrong team or scopes.
+- Treat policy and transaction IDs as opaque strings.
+- Validate HTTP status codes before reading a success response.
+- Read `error.code` for program logic and `error.details` for field-level validation failures.
+- Prefer the idempotent access-rule operations when synchronizing allowlists.
+- Use `PUT /transactions` only when your system owns the complete ordered list.
+- Keep policies disabled until all required restrictions and funding are in place.
+
+## Machine-readable specification
+
+Download the complete [OpenAPI 3.1 specification](/openapi/platform-api.yaml) for client generation and agent tooling.

--- a/docs/wallet/api/authenticated-endpoints.md
+++ b/docs/wallet/api/authenticated-endpoints.md
@@ -8,6 +8,10 @@ keywords: [api key, bundler endpoint, paymaster endpoint, authentication, rate l
 
 Production integrations use authenticated endpoints with an API key. Get yours from [Candide's Dashboard](https://dashboard.candide.dev). No sales call required.
 
+:::info API keys and management keys are different
+This page covers runtime Bundler and Paymaster API keys. The [Platform API](/platform/overview) uses a separate team management key in an `Authorization: Bearer` header to create and maintain gas policies. Never expose a management key in client-side code.
+:::
+
 ## Endpoint URL Format
 
 One URL serves both the **Bundler** and **Paymaster** APIs. Add the chain ID and your API key:

--- a/docs/wallet/intro.mdx
+++ b/docs/wallet/intro.mdx
@@ -101,7 +101,7 @@ export const GETTING_STARTED_ITEMS = [
 | [Bundler](/wallet/bundler/rpc-methods/) | ERC-4337 compliant nodes for submitting UserOperations on all major EVM chains |
 | [Paymaster](/wallet/paymaster/rpc-methods/) | Sponsor gas or accept ERC-20 token payments with configurable policies |
 | [Solana Paymaster](/wallet/guides/pay-gas-in-usdt-solana/) | Gasless Solana transactions with fees collected in USDT. Built on Kora |
-| [InstaGas](/instagas/overview/) | No-code dashboard to set gas sponsorship rules |
+| [InstaGas](/instagas/overview/) | Dashboard and [Platform API](/platform/overview) for managing gas sponsorship rules |
 | [Forwarding Address](/forwarding-address/overview/) | One deposit address per user that routes funds from any supported chain to the destination wallet |
 | [Account Recovery](/wallet/recovery/overview/) | Email/SMS recovery with an alert system and automatic on-chain execution |
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build && node scripts/fix-markdown-links.js",
+    "test:markdown-links": "node --test scripts/fix-markdown-links.test.js",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/scripts/fix-markdown-links.js
+++ b/scripts/fix-markdown-links.js
@@ -9,6 +9,9 @@
  *
  * This script fixes them to:
  *   https://docs.candide.dev/wallet/paymaster/tokens-supported.md (correct)
+ * The same malformed links can appear in llms-full.txt, so generated LLM text
+ * artifacts are processed alongside per-page Markdown files.
+ *
  *
  * It also fixes relative path versions like /wallet/paymaster/tokens-supported/.md
  */
@@ -34,6 +37,12 @@ function fixMarkdownLinks(filePath) {
     return beforeSlash + ending;
   });
 
+  // Fix links with fragments: /path/.md#section -> /path.md#section
+  content = content.replace(/\/\.md(?=#[^\s)]*(?:\)|\s))/g, () => {
+    modified = true;
+    return '.md';
+  });
+
   if (modified) {
     fs.writeFileSync(filePath, content, 'utf8');
     const relativePath = path.relative(BUILD_DIR, filePath);
@@ -54,7 +63,10 @@ function processDirectory(dir) {
 
     if (entry.isDirectory()) {
       filesFixed += processDirectory(fullPath);
-    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+    } else if (
+      entry.isFile() &&
+      (entry.name.endsWith('.md') || /^llms(?:-full)?\.txt$/.test(entry.name))
+    ) {
       filesFixed += fixMarkdownLinks(fullPath);
     }
   }

--- a/scripts/fix-markdown-links.js
+++ b/scripts/fix-markdown-links.js
@@ -38,7 +38,7 @@ function fixMarkdownLinks(filePath) {
   });
 
   // Fix links with fragments: /path/.md#section -> /path.md#section
-  content = content.replace(/\/\.md(?=#[^\s)]*(?:\)|\s))/g, () => {
+  content = content.replace(/\/\.md(?=#[^\s)]*(?:\)|\s|$))/g, () => {
     modified = true;
     return '.md';
   });
@@ -74,6 +74,10 @@ function processDirectory(dir) {
   return filesFixed;
 }
 
-console.log('Fixing markdown links in build directory...\n');
-const filesFixed = processDirectory(BUILD_DIR);
-console.log(`\n✅ Fixed broken links in ${filesFixed} file(s)`);
+if (require.main === module) {
+  console.log('Fixing markdown links in build directory...\n');
+  const filesFixed = processDirectory(BUILD_DIR);
+  console.log(`\n✅ Fixed broken links in ${filesFixed} file(s)`);
+}
+
+module.exports = { fixMarkdownLinks };

--- a/scripts/fix-markdown-links.test.js
+++ b/scripts/fix-markdown-links.test.js
@@ -1,0 +1,29 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const { fixMarkdownLinks } = require('./fix-markdown-links');
+
+test('fixes a fragment link that ends at EOF', (t) => {
+  const testDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'fix-markdown-links-'),
+  );
+  const filePath = path.join(testDir, 'llms-full.txt');
+
+  t.after(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  fs.writeFileSync(
+    filePath,
+    'https://docs.candide.dev/path/.md#section',
+  );
+
+  assert.equal(fixMarkdownLinks(filePath), 1);
+  assert.equal(
+    fs.readFileSync(filePath, 'utf8'),
+    'https://docs.candide.dev/path.md#section',
+  );
+});

--- a/sidebars.js
+++ b/sidebars.js
@@ -46,6 +46,25 @@ const sidebars = {
   infraSideBar: [
     {
       type: "category",
+      label: "Platform API",
+      className: "category-not-collapsible",
+      collapsible: false,
+      collapsed: false,
+      items: [
+        {
+          type: "doc",
+          id: "platform/overview",
+          label: "Overview"
+        },
+        {
+          type: "doc",
+          id: "platform/gas-policy-api",
+          label: "Gas Policy API"
+        },
+      ],
+    },
+    {
+      type: "category",
       label: "Bundler & Paymaster",
       className: "category-not-collapsible",
       collapsible: false,

--- a/static/openapi/platform-api.yaml
+++ b/static/openapi/platform-api.yaml
@@ -1,0 +1,799 @@
+openapi: 3.1.0
+
+info:
+  title: Candide Gas Policy Management API
+  version: "1.0.0"
+  license:
+    name: Proprietary
+  description: >-
+    Team-scoped REST API for managing gas policies, authenticated with a team
+    management key. Every route is scoped to the team that owns the key.
+
+servers:
+  - url: https://platform-api.candide.dev
+
+security:
+  - bearerAuth: []
+
+tags:
+  - name: Identity
+    description: "Information about the calling management key."
+  - name: Gas Policies
+    description: "Create, read, update and delete gas policies."
+  - name: Access Rules
+    description: "Account, origin and IP whitelists of a policy."
+  - name: Transactions
+    description: "Allowed target transactions of a policy."
+
+paths:
+  /v1/me:
+    get:
+      tags: [Identity]
+      operationId: getKeyInfo
+      summary: "Return the calling key's team and scopes."
+      responses:
+        "200":
+          description: "Key info."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/KeyInfo"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  /v1/gas-policies:
+    get:
+      tags: [Gas Policies]
+      operationId: listGasPolicies
+      summary: "List the team's gas policies. Requires scope gas-policies:read."
+      parameters:
+        - name: chainId
+          in: query
+          description: "Filter by chain id."
+          schema:
+            type: integer
+        - name: enabled
+          in: query
+          description: "Filter by enabled state."
+          schema:
+            type: boolean
+        - name: page
+          in: query
+          description: "Zero-based page index."
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+        - name: pageSize
+          in: query
+          description: "Items per page."
+          schema:
+            type: integer
+            enum: [10, 25, 50, 100]
+            default: 25
+      responses:
+        "200":
+          description: "Paginated policies."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PolicyList"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+    post:
+      tags: [Gas Policies]
+      operationId: createGasPolicy
+      summary: "Create a gas policy. Requires scope gas-policies:write."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PolicyCreate"
+      responses:
+        "201":
+          description: "Created policy."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PolicyDetail"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  /v1/gas-policies/{policyId}:
+    parameters:
+      - $ref: "#/components/parameters/PolicyId"
+    get:
+      tags: [Gas Policies]
+      operationId: getGasPolicy
+      summary: "Fetch one gas policy. Requires scope gas-policies:read."
+      responses:
+        "200":
+          description: "Policy detail."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PolicyDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+    patch:
+      tags: [Gas Policies]
+      operationId: updateGasPolicy
+      summary: "Update any subset of a policy's fields. Requires scope gas-policies:write."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PolicyUpdate"
+      responses:
+        "200":
+          description: "Updated policy."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PolicyDetail"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+    delete:
+      tags: [Gas Policies]
+      operationId: deleteGasPolicy
+      summary: "Delete a policy. Requires scope gas-policies:write."
+      responses:
+        "200":
+          description: "Deletion acknowledged."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  /v1/gas-policies/{policyId}/access-rules:
+    parameters:
+      - $ref: "#/components/parameters/PolicyId"
+    patch:
+      tags: [Access Rules]
+      operationId: updateAccessRules
+      summary: "Add, remove or replace whitelist entries. Requires scope gas-policies:write."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AccessRulesUpdate"
+      responses:
+        "200":
+          description: "Updated policy."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PolicyDetail"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  /v1/gas-policies/{policyId}/transactions:
+    parameters:
+      - $ref: "#/components/parameters/PolicyId"
+    put:
+      tags: [Transactions]
+      operationId: replaceTransactions
+      summary: "Replace the ordered transaction list. Requires scope gas-policies:write."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [transactions]
+              properties:
+                transactions:
+                  type: array
+                  description: "Desired transaction list, in order."
+                  items:
+                    $ref: "#/components/schemas/TransactionInput"
+      responses:
+        "200":
+          description: "Updated policy."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PolicyDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+    post:
+      tags: [Transactions]
+      operationId: addTransaction
+      summary: "Append one transaction. Requires scope gas-policies:write."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TransactionInput"
+      responses:
+        "201":
+          description: "Created transaction and the updated policy."
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  transactionId:
+                    type: string
+                    description: "Id of the created transaction."
+                  policy:
+                    $ref: "#/components/schemas/PolicyDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  /v1/gas-policies/{policyId}/transactions/{transactionId}:
+    parameters:
+      - $ref: "#/components/parameters/PolicyId"
+      - name: transactionId
+        in: path
+        required: true
+        description: "Transaction id."
+        schema:
+          type: string
+    delete:
+      tags: [Transactions]
+      operationId: removeTransaction
+      summary: "Remove one transaction. Requires scope gas-policies:write."
+      responses:
+        "200":
+          description: "Updated policy."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PolicyDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: "Team management key, sent as an Authorization Bearer token (mk_...)."
+
+  parameters:
+    PolicyId:
+      name: policyId
+      in: path
+      required: true
+      description: "Gas policy id."
+      schema:
+        type: string
+
+  responses:
+    BadRequest:
+      description: |
+        Malformed request. Messages:
+        "Request body is not valid JSON."
+        "chainId must be an integer."
+        "enabled must be 'true' or 'false'."
+        "page must be a non-negative integer."
+        "pageSize must be one of 10, 25, 50, 100."
+        "Chain {chainId} is not available for this team."
+        "Provide at least one field to update: name, general, accountRules, accessRules."
+        "Provide at least one of: accounts, origins, ips."
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    Unauthorized:
+      description: |
+        Missing or invalid management key. Messages:
+        "Missing or malformed Authorization header. Use 'Authorization: Bearer <management_key>'."
+        "Missing management key."
+        "Invalid management key."
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    Forbidden:
+      description: |
+        Messages:
+        "This management key is missing the required scope: {scope}"
+        "Your plan does not allow more than {n} gas policies on mainnets. Upgrade your plan for more."
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    NotFound:
+      description: |
+        Unknown, deleted or cross-team resource. Messages:
+        "Gas policy not found."
+        "Transaction {transactionId} not found on this policy."
+        "The requested endpoint does not exist."
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    ValidationError:
+      description: |
+        Message: "Request validation failed."
+        `details` maps each rejected field to its reason, for example
+        {"accountRules.maxPerOp": "must be a valid non-negative hex amount"}.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    ServerError:
+      description: |
+        Message: "An unexpected error occurred."
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+
+  schemas:
+    Error:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+              description: "Machine-readable error code."
+              enum:
+                - bad_request
+                - unauthorized
+                - forbidden
+                - not_found
+                - validation_error
+                - internal_error
+            message:
+              type: string
+              description: "Human-readable message."
+            details:
+              type: object
+              description: "Present on validation errors; maps a field path to its reason."
+              additionalProperties:
+                type: string
+
+    KeyInfo:
+      type: object
+      properties:
+        keyId:
+          type: string
+          description: "Management key id."
+        teamId:
+          type: string
+          description: "Team the key belongs to."
+        scopes:
+          type: array
+          description: "Scopes granted to the key."
+          items:
+            type: string
+            enum: ["gas-policies:read", "gas-policies:write"]
+
+    PolicyList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: "Policies on this page."
+          items:
+            $ref: "#/components/schemas/PolicyListItem"
+        total:
+          type: integer
+          description: "Total policies matching the filters."
+        page:
+          type: integer
+          description: "Zero-based page index."
+        pageSize:
+          type: integer
+          description: "Items per page."
+
+    PolicyListItem:
+      type: object
+      properties:
+        id:
+          type: string
+          description: "Policy id."
+        name:
+          type: string
+          description: "Display name."
+        chainId:
+          type: integer
+          description: "Chain the policy sponsors on."
+        enabled:
+          type: boolean
+          description: "Whether the policy is active."
+        private:
+          type: boolean
+          description: "Private policies must be requested by their sponsorship policy id."
+        createdAt:
+          type: integer
+          description: "Creation time in milliseconds since epoch."
+        billing:
+          $ref: "#/components/schemas/Billing"
+
+    PolicyDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          description: "Policy id."
+        name:
+          type: string
+          description: "Display name."
+        chainId:
+          type: integer
+          description: "Chain the policy sponsors on."
+        createdAt:
+          type: integer
+          description: "Creation time in milliseconds since epoch."
+        general:
+          $ref: "#/components/schemas/General"
+        accountRules:
+          $ref: "#/components/schemas/AccountRules"
+        accessRules:
+          $ref: "#/components/schemas/AccessRules"
+        transactions:
+          type: array
+          description: "Allowed target transactions, in order."
+          items:
+            $ref: "#/components/schemas/Transaction"
+        billing:
+          $ref: "#/components/schemas/Billing"
+
+    General:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          description: "Whether the policy is active."
+        private:
+          type: boolean
+          description: "Private policies must be requested by their sponsorship policy id."
+        sponsorshipPolicyId:
+          type: string
+          description: "Public id used to request this policy."
+        startDate:
+          type: integer
+          description: "Active from, in milliseconds since epoch."
+        endDate:
+          type: integer
+          description: "Active until, in milliseconds since epoch."
+
+    AccountRules:
+      type: object
+      properties:
+        rate:
+          type: integer
+          description: "Max sponsorships per account per period; -1 disables rate limiting."
+        ratePeriod:
+          type: integer
+          description: "Rate limit window in seconds."
+        totalMax:
+          type: string
+          description: "Max total gas spend per account, hex wei."
+        maxPerOp:
+          type: string
+          description: "Max gas spend for a single user operation, hex wei."
+
+    AccessRules:
+      type: object
+      properties:
+        accounts:
+          $ref: "#/components/schemas/AccessRule"
+        origins:
+          $ref: "#/components/schemas/AccessRule"
+        ips:
+          $ref: "#/components/schemas/AccessRule"
+
+    AccessRule:
+      type: object
+      properties:
+        allowAll:
+          type: boolean
+          description: "When true every value is allowed and entries is empty."
+        entries:
+          type: array
+          description: "Whitelisted entries."
+          items:
+            type: object
+            properties:
+              value:
+                type: string
+                description: "Whitelisted value."
+              label:
+                type: string
+                description: "Optional note; defaults to a dash."
+
+    Transaction:
+      type: object
+      properties:
+        id:
+          type: string
+          description: "Transaction id."
+        to:
+          type: string
+          description: 'Target contract address, or the "${userop.sender}" literal.'
+        contractName:
+          type: string
+          description: "Resolved contract name, or a dash when unknown."
+        selector:
+          type: string
+          description: "4-byte function selector."
+        abi:
+          type: string
+          description: "JSON ABI fragment."
+        parameters:
+          type: array
+          description: "Constraints on the call arguments."
+          items:
+            $ref: "#/components/schemas/TransactionParameter"
+
+    TransactionParameter:
+      type: object
+      properties:
+        index:
+          type: string
+          description: 'Argument index; use ";" to reach into tuples, e.g. "0;3".'
+        operator:
+          type: string
+          description: "Comparison operator allowed for the argument type."
+          enum: ["$eq", "$gt", "$gte", "$lt", "$lte", "$startsWith"]
+        value:
+          type: string
+          description: "Value the argument is compared against."
+
+    Billing:
+      type: object
+      properties:
+        currency:
+          type: string
+          description: "Native token symbol of the chain."
+        balance:
+          type: string
+          description: "Total funds, hex wei."
+        lockedBalance:
+          type: string
+          description: "Funds reserved for in-flight operations, hex wei."
+        available:
+          type: string
+          description: "Balance minus locked, hex wei."
+
+    PolicyCreate:
+      type: object
+      required: [name, chainId]
+      properties:
+        name:
+          type: string
+          minLength: 3
+          maxLength: 50
+          description: "Display name."
+        chainId:
+          type: integer
+          description: "Chain to sponsor on; must be enabled for the team."
+        general:
+          $ref: "#/components/schemas/GeneralInput"
+        accountRules:
+          $ref: "#/components/schemas/AccountRulesInput"
+        accessRules:
+          $ref: "#/components/schemas/AccessRulesInput"
+        transactions:
+          type: array
+          description: "Initial transaction list."
+          items:
+            $ref: "#/components/schemas/TransactionInput"
+
+    PolicyUpdate:
+      type: object
+      description: "At least one field is required. Omitted fields are left unchanged."
+      minProperties: 1
+      properties:
+        name:
+          type: string
+          minLength: 3
+          maxLength: 50
+          description: "Display name."
+        general:
+          $ref: "#/components/schemas/GeneralInput"
+        accountRules:
+          $ref: "#/components/schemas/AccountRulesInput"
+        accessRules:
+          $ref: "#/components/schemas/AccessRulesInput"
+
+    GeneralInput:
+      type: object
+      description: "Merged over the current values."
+      properties:
+        enabled:
+          type: boolean
+          description: "Whether the policy is active."
+        private:
+          type: boolean
+          description: "Require the sponsorship policy id to match."
+        startDate:
+          type: integer
+          description: "Active from, ms since epoch; cannot move more than a day into the past."
+        endDate:
+          type: integer
+          description: "Active until, ms since epoch; must be after startDate."
+
+    AccountRulesInput:
+      type: object
+      description: "Merged over the current values."
+      properties:
+        rate:
+          type: integer
+          description: "Positive limit, or -1 for no rate limiting."
+        ratePeriod:
+          type: integer
+          description: "Window in seconds; required unless rate is -1."
+          enum: [3600, 43200, 86400, 604800, 1296000, 2592000, 3153600000]
+        totalMax:
+          type: string
+          description: "Max total gas spend per account, hex wei."
+        maxPerOp:
+          type: string
+          description: "Max gas spend per user operation, hex wei."
+
+    AccessRulesInput:
+      type: object
+      description: "Replaces each listed whitelist; an empty list means allow all."
+      properties:
+        accounts:
+          $ref: "#/components/schemas/AccessEntryList"
+        origins:
+          $ref: "#/components/schemas/AccessEntryList"
+        ips:
+          $ref: "#/components/schemas/AccessEntryList"
+
+    AccessEntryList:
+      type: array
+      description: "Entries; an address, https origin or IPv4 depending on the rule."
+      items:
+        oneOf:
+          - type: string
+          - type: object
+            required: [value]
+            properties:
+              value:
+                type: string
+                description: "Whitelisted value."
+              label:
+                type: string
+                description: "Optional note."
+
+    AccessRulesUpdate:
+      type: object
+      description: "At least one rule is required."
+      minProperties: 1
+      properties:
+        accounts:
+          $ref: "#/components/schemas/AccessRuleOps"
+        origins:
+          $ref: "#/components/schemas/AccessRuleOps"
+        ips:
+          $ref: "#/components/schemas/AccessRuleOps"
+
+    AccessRuleOps:
+      type: object
+      description: >-
+        Use add and remove together, or set or allowAll alone; combining the two
+        groups is rejected. add and remove are idempotent, and remove is applied
+        first.
+      minProperties: 1
+      properties:
+        add:
+          description: "Entries to append; values already present are skipped."
+          $ref: "#/components/schemas/AccessEntryList"
+        remove:
+          description: "Values to drop; values not present are ignored."
+          $ref: "#/components/schemas/AccessEntryList"
+        set:
+          description: "Replaces the whole list; an empty list means allow all."
+          $ref: "#/components/schemas/AccessEntryList"
+        allowAll:
+          type: boolean
+          description: "Set to true to reset the rule to allow all."
+
+    TransactionInput:
+      type: object
+      required: [to, abi, selector, parameters]
+      properties:
+        to:
+          type: string
+          description: 'Target contract address, or the "${userop.sender}" literal.'
+        abi:
+          type: string
+          description: "JSON ABI fragment containing the function."
+        selector:
+          type: string
+          description: "4-byte function selector, 8 hex characters."
+        parameters:
+          type: array
+          description: "Constraints on the call arguments; may be empty."
+          items:
+            $ref: "#/components/schemas/TransactionParameter"
+
+    DeleteResult:
+      type: object
+      properties:
+        id:
+          type: string
+          description: "Deleted policy id."
+        deleted:
+          type: boolean
+          description: "Always true."


### PR DESCRIPTION
## Summary

- add a human-friendly Platform API overview and safe gas-policy quickstart
- document all gas-policy, access-rule, transaction, identity, response, and error contracts
- publish the OpenAPI 3.1 specification and expose the new Platform API sidebar category
- reconcile existing InstaGas terminology and distinguish management keys from runtime API keys
- fix generated `llms-full.txt` links so coding agents receive valid Markdown targets

## Why

Developers could previously configure gas policies only through the Dashboard. This documents the new team-scoped REST API for backend services, deployment automation, and coding agents while keeping the runtime Paymaster API distinction clear.

## Validation

- `yarn build`
- parsed every JSON example
- parsed the OpenAPI YAML, resolved all local references, and verified 10 unique operation IDs
- verified both new pages appear in `llms.txt` and `llms-full.txt`
- verified the published OpenAPI artifact matches the checked-in source
- verified generated LLM Markdown contains no malformed `/.md` links


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added complete Platform API documentation and quickstart guidance for managing gas policies (create, list, update, enable, delete).
  - Added a dedicated Gas Policy Management API reference, including authentication, access rules, transactions, pagination, and error behavior.
  - Added a machine-readable OpenAPI 3.1 specification for client generation.
  - Updated documentation navigation to include a Platform API section.

- **Documentation**
  - Updated InstaGas policy examples and field references to match the public API.
  - Clarified that management keys must not be used in client-side runtime contexts.

- **Tests**
  - Added automated coverage for Markdown link normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->