### PR TITLE
docs: add Solana to supported gas tokens

### DIFF
--- a/docs/wallet/paymaster/1-tokens-supported.mdx
+++ b/docs/wallet/paymaster/1-tokens-supported.mdx
@@ -1,6 +1,6 @@
 ---
-title: List of ERC-20 Tokens Supported as Gas Payments with Candide Paymaster
-description: List of ERC-20 Token accepted for Candide's Paymaster. Learn about sponsoring gas, and how to enable gas payments in stablecoins
+title: List of Gas Tokens Supported with Candide Paymaster
+description: List of Gas Tokens accepted for Candide's Paymaster. Learn about sponsoring gas, and how to enable gas payments in stablecoins
 image: /img/posters/paymaster-meta.png
 keywords: [paymaster, gas sponsorship, pay gas in stablecoin]
 ---
@@ -17,6 +17,7 @@ import {
     ethereumList,
     gnosisList,
     optimismList,
+    solanaList,
     worldchainList,
     arbitrumSepoliaList,
     amoyList,
@@ -25,12 +26,12 @@ import {
     sepoliaList,
 } from "/src/data/tokens-list.ts";
 
-List of ERC-20 Tokens accepted by Candide's Paymaster. Visit the [dashboard](https://dashboard.candide.dev) to get an API key. 
+List of tokens accepted by Candide's Paymaster for gas payments. Visit the [dashboard](https://dashboard.candide.dev) to get an API key.
 
-We constantly add support for new ERC-20 tokens as gas payments. To check for the latest list of supported tokens, developers can:
+We constantly add support for new tokens and networks. To check the live list available to your API key:
 
-- Call the [`pm_supportedERC20Tokens`](/wallet/paymaster/rpc-methods/#pm_supportederc20tokens) API endpoint
-- Use the SDK's [`fetchSupportedERC20TokensAndPaymasterMetadata`](https://docs.candide.dev/wallet/abstractionkit/safe-account/#fetchsupportederc20tokensandpaymastermetadata) method
+- On EVM networks, call [`pm_supportedERC20Tokens`](/wallet/paymaster/rpc-methods/#pm_supportederc20tokens) or use the SDK's [`fetchSupportedERC20TokensAndPaymasterMetadata`](https://docs.candide.dev/wallet/abstractionkit/safe-account/#fetchsupportederc20tokensandpaymastermetadata) method
+- On Solana, call [`getSupportedTokens`](/wallet/solana-paymaster/rpc-methods/#getsupportedtokens)
 
 :::info
 If you would like to see a token or network supported, email team@candidelabs.com
@@ -68,6 +69,8 @@ If you would like to see a token or network supported, email team@candidelabs.co
 ### Plasma
 <PaymasterSupportedToken items={plasmaList} />
 
+### Solana
+<PaymasterSupportedToken items={solanaList} />
 
 ### Worldchain Mainnet
 <PaymasterSupportedToken items={worldchainList}/>

--- a/docs/wallet/paymaster/1-tokens-supported.mdx
+++ b/docs/wallet/paymaster/1-tokens-supported.mdx
@@ -1,8 +1,8 @@
 ---
-title: List of Gas Tokens Supported with Candide Paymaster
-description: List of Gas Tokens accepted for Candide's Paymaster. Learn about sponsoring gas, and how to enable gas payments in stablecoins
+title: Supported Gas Payment Tokens
+description: Tokens accepted by Candide's Paymaster for gas payments across EVM networks and Solana.
 image: /img/posters/paymaster-meta.png
-keywords: [paymaster, gas sponsorship, pay gas in stablecoin]
+keywords: [paymaster, gas sponsorship, gas token, ERC-20, SPL token, Solana, USDT]
 ---
 
 import { plasmaList } from "../../../src/data/tokens-list";
@@ -26,9 +26,9 @@ import {
     sepoliaList,
 } from "/src/data/tokens-list.ts";
 
-List of tokens accepted by Candide's Paymaster for gas payments. Visit the [dashboard](https://dashboard.candide.dev) to get an API key.
+Candide's Paymaster lets users pay gas with supported tokens instead of a network's native token. Visit the [dashboard](https://dashboard.candide.dev) to get an API key.
 
-We constantly add support for new tokens and networks. To check the live list available to your API key:
+The tables below show the documented baseline. Availability can vary by API key, so use these methods as the source of truth:
 
 - On EVM networks, call [`pm_supportedERC20Tokens`](/wallet/paymaster/rpc-methods/#pm_supportederc20tokens) or use the SDK's [`fetchSupportedERC20TokensAndPaymasterMetadata`](https://docs.candide.dev/wallet/abstractionkit/safe-account/#fetchsupportederc20tokensandpaymastermetadata) method
 - On Solana, call [`getSupportedTokens`](/wallet/solana-paymaster/rpc-methods/#getsupportedtokens)

--- a/sidebars.js
+++ b/sidebars.js
@@ -282,25 +282,17 @@ const sidebars = {
         {
           type: "doc",
           id: "wallet/paymaster/rpc-methods",
-          label: "RPC Methods"
+          label: "EVM RPC Methods"
+        },
+        {
+          type: "doc",
+          id: "wallet/solana-paymaster/rpc-methods",
+          label: "Solana RPC Methods"
         },
         {
           type: "doc",
           id: "wallet/paymaster/tokens-supported",
-          label: "Supported ERC-20 Tokens"
-        },
-      ],
-    },
-    {
-      type: "category",
-      label: "Solana Paymaster",
-      className: "category-not-collapsible",
-      collapsible: false,
-      items: [
-        {
-          type: "doc",
-          id: "wallet/solana-paymaster/rpc-methods",
-          label: "RPC Methods"
+          label: "Supported Gas Tokens"
         },
       ],
     },

--- a/src/components/CustomTable.js
+++ b/src/components/CustomTable.js
@@ -64,7 +64,7 @@ export function PaymasterSupportedToken({ items }) {
     <Table
       items={items}
       leftHeading="Token"
-      centerHeading="Address"
+      centerHeading="Contract / Mint Address"
       rightHeading="Website"
       renderLeftItem={(item) => (
         <div

--- a/src/data/tokens-list.ts
+++ b/src/data/tokens-list.ts
@@ -290,6 +290,16 @@ export const plasmaList = [
   },
 ];
 
+export const solanaList = [
+  {
+    token: "USDT",
+    logo: "/img/tokens/usdt-logo.svg",
+    address: "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+    blockExplorer: "https://explorer.solana.com/address/",
+    website: "https://tether.io/",
+  },
+];
+
 export const worldchainList = [
   {
     token: "USDC.e (Bridged)",


### PR DESCRIPTION
## Summary

- group the EVM and Solana RPC references under the Paymaster documentation
- rename the token page and sidebar entry to cover gas tokens across networks
- add Solana mainnet and its supported USDT mint to the token list
- link readers and coding agents to the live token-discovery method for each platform

## Validation

- yarn build
- git diff --check
- verified the generated Markdown and HTML include Solana, USDT, and the canonical mint address

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Solana mainnet support to the Paymaster supported-token listings, including USDT.
  * Added separate navigation for EVM and Solana RPC methods.
  * Renamed the supported-token section to “Supported Gas Tokens.”

* **Documentation**
  * Clarified that available tokens depend on the API key.
  * Added guidance for finding supported tokens through the appropriate RPC and SDK methods.
  * Updated token address labeling to cover both contract and mint addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->