### PR TITLE
docs: fix gas policy transaction examples

### DIFF
--- a/docs/instagas/2-gas-policies.mdx
+++ b/docs/instagas/2-gas-policies.mdx
@@ -122,9 +122,9 @@ For request validation, update semantics, and response fields, use the [Gas Poli
     {
       "to": "0xE592427A0AEce92De3Edee1F18E0157C05861564",
       "selector": "0x414bf389",
-      "abi": "{\"name\": \"exactInputSingle\", \"type\": \"function\", ...}",
+      "abi": "[{\"type\":\"function\",\"name\":\"exactInputSingle\",\"constant\":false,\"payable\":true,\"inputs\":[{\"type\":\"tuple\",\"name\":\"params\",\"components\":[{\"type\":\"address\",\"name\":\"tokenIn\"},{\"type\":\"address\",\"name\":\"tokenOut\"},{\"type\":\"uint24\",\"name\":\"fee\"},{\"type\":\"address\",\"name\":\"recipient\"},{\"type\":\"uint256\",\"name\":\"deadline\"},{\"type\":\"uint256\",\"name\":\"amountIn\"},{\"type\":\"uint256\",\"name\":\"amountOutMinimum\"},{\"type\":\"uint160\",\"name\":\"sqrtPriceLimitX96\"}]}],\"outputs\":[{\"type\":\"uint256\",\"name\":\"amountOut\"}]}]",
       "parameters": [
-        { "index": "0;5", "operator": "$gte", "value": "1000000" }
+        { "index": "0;5", "operator": "$gte", "value": "0x0f4240" }
       ]
     }
   ]
@@ -168,7 +168,7 @@ Each entry describes one allowed contract call. Constraints within an entry must
 | :--- | :--- | :--- |
 | `to` | `string` (address) | The contract the call must target. |
 | `selector` | `string` (4-byte hex) | The function selector the call must invoke. |
-| `abi` | `string` | The ABI fragment of the function, used to decode call parameters for constraint checks. |
+| `abi` | `string` | A JSON-stringified ABI array containing the complete function fragment, used to decode call parameters for constraint checks. |
 | `parameters` | `constraint[]` | Constraints on the decoded call parameters. Empty sponsors any call to this function. |
 
 Each parameter constraint:
@@ -177,7 +177,7 @@ Each parameter constraint:
 | :--- | :--- | :--- |
 | `index` | `string` | Argument index. Use semicolons for nested tuples: `0;5` targets the sixth field of the first argument. |
 | `operator` | `string` | One of the operators below. |
-| `value` | `string` | The value the decoded argument is compared against. Token amounts are in the token's smallest unit. |
+| `value` | `string` | The value the decoded argument is compared against. Encode `uint` and `bytes` values as `0x`-prefixed hexadecimal strings. Token amounts are in the token's smallest unit. |
 
 Supported operators:
 

--- a/docs/platform/gas-policy-api.mdx
+++ b/docs/platform/gas-policy-api.mdx
@@ -266,13 +266,13 @@ curl --request PUT \
     "transactions": [
       {
         "to": "0x1111111111111111111111111111111111111111",
-        "abi": "{\"type\":\"function\",\"name\":\"transfer\",\"inputs\":[{\"name\":\"to\",\"type\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\"}]}",
+        "abi": "[{\"type\":\"function\",\"name\":\"transfer\",\"constant\":false,\"payable\":false,\"inputs\":[{\"type\":\"address\",\"name\":\"to\"},{\"type\":\"uint256\",\"name\":\"amount\"}],\"outputs\":[{\"type\":\"bool\",\"name\":\"\"}]}]",
         "selector": "0xa9059cbb",
         "parameters": [
           {
             "index": "1",
             "operator": "$lte",
-            "value": "1000000"
+            "value": "0x0f4240"
           }
         ]
       }
@@ -295,7 +295,7 @@ curl --request POST \
   --header "Content-Type: application/json" \
   --data '{
     "to": "${userop.sender}",
-    "abi": "{\"type\":\"function\",\"name\":\"execute\",\"inputs\":[]}",
+    "abi": "[{\"type\":\"function\",\"name\":\"execute\",\"constant\":false,\"payable\":false,\"inputs\":[],\"outputs\":[]}]",
     "selector": "0x61461954",
     "parameters": []
   }'
@@ -333,7 +333,7 @@ curl --request POST \
         "to": "${userop.sender}",
         "contractName": "-",
         "selector": "0x61461954",
-        "abi": "{\"type\":\"function\",\"name\":\"execute\",\"inputs\":[]}",
+        "abi": "[{\"type\":\"function\",\"name\":\"execute\",\"constant\":false,\"payable\":false,\"inputs\":[],\"outputs\":[]}]",
         "parameters": []
       }
     ],
@@ -396,7 +396,7 @@ All fields are optional and merge over the current account rules.
 | Field | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | `to` | string | Yes | Target contract address or the literal `"${userop.sender}"` |
-| `abi` | string | Yes | JSON ABI fragment containing the function |
+| `abi` | string | Yes | JSON-stringified ABI array containing the complete function fragment |
 | `selector` | string | Yes | Four-byte function selector with eight hex digits |
 | `parameters` | transaction parameter[] | Yes | Argument constraints; may be empty |
 
@@ -406,7 +406,7 @@ Each transaction parameter has:
 | :--- | :--- | :--- |
 | `index` | string | Argument index. Use semicolons to descend into tuples, for example `"0;3"` |
 | `operator` | string | `$eq`, `$gt`, `$gte`, `$lt`, `$lte`, or `$startsWith` |
-| `value` | string | Value to compare against |
+| `value` | string | Value to compare against. Encode `uint` and `bytes` values as `0x`-prefixed hexadecimal strings; use `"true"` or `"false"` for booleans |
 
 ## Response models
 

--- a/package.json
+++ b/package.json
@@ -5,12 +5,15 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
+    "prebuild": "npm run test:gas-policy-examples",
     "build": "docusaurus build && node scripts/fix-markdown-links.js",
     "test:markdown-links": "node --test scripts/fix-markdown-links.test.js",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
+    "test:gas-policy-examples": "node --test scripts/gas-policy-api-examples.test.js",
+    "test:gas-policy-api-integration": "node --test scripts/gas-policy-api-integration.test.js",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids"
   },

--- a/scripts/gas-policy-api-examples.test.js
+++ b/scripts/gas-policy-api-examples.test.js
@@ -1,0 +1,50 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const pagePath = path.join(__dirname, "..", "docs", "platform", "gas-policy-api.mdx");
+const page = fs.readFileSync(pagePath, "utf8");
+
+function replaceTransactionsBody() {
+  const section = page.match(
+    /### Replace all transactions([\s\S]*?)(?=\n### )/,
+  );
+  assert.ok(section, "Replace all transactions section is missing");
+
+  const data = section[1].match(/--data '(\{[\s\S]*\})'\n```/);
+  assert.ok(data, "PUT example request body is missing");
+  return JSON.parse(data[1]);
+}
+
+test("published PUT transaction example uses the API's accepted formats", () => {
+  const body = replaceTransactionsBody();
+  assert.equal(body.transactions.length, 1);
+
+  const transaction = body.transactions[0];
+  const abi = JSON.parse(transaction.abi);
+
+  assert.ok(Array.isArray(abi), "abi must be a JSON-stringified array");
+  assert.equal(abi.length, 1);
+  assert.deepEqual(abi[0], {
+    type: "function",
+    name: "transfer",
+    constant: false,
+    payable: false,
+    inputs: [
+      { type: "address", name: "to" },
+      { type: "uint256", name: "amount" },
+    ],
+    outputs: [{ type: "bool", name: "" }],
+  });
+  assert.equal(transaction.selector, "0xa9059cbb");
+
+  assert.deepEqual(transaction.parameters, [
+    {
+      index: "1",
+      operator: "$lte",
+      value: "0x0f4240",
+    },
+  ]);
+  assert.match(transaction.parameters[0].value, /^0x[0-9a-f]+$/i);
+});

--- a/scripts/gas-policy-api-integration.test.js
+++ b/scripts/gas-policy-api-integration.test.js
@@ -1,0 +1,82 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const managementKey = process.env.CANDIDE_MANAGEMENT_KEY;
+const testPolicyId = process.env.CANDIDE_GAS_POLICY_TEST_POLICY_ID;
+const baseUrl = process.env.CANDIDE_PLATFORM_API_URL ?? "https://platform-api.candide.dev";
+
+const pagePath = path.join(__dirname, "..", "docs", "platform", "gas-policy-api.mdx");
+const page = fs.readFileSync(pagePath, "utf8");
+
+function replaceTransactionsBody() {
+  const section = page.match(
+    /### Replace all transactions([\s\S]*?)(?=\n### )/,
+  );
+  assert.ok(section, "Replace all transactions section is missing");
+
+  const data = section[1].match(/--data '(\{[\s\S]*\})'\n```/);
+  assert.ok(data, "PUT example request body is missing");
+  return JSON.parse(data[1]);
+}
+
+test(
+  "published PUT transaction example is accepted by the Platform API",
+  {
+    skip:
+      !managementKey || !testPolicyId
+        ? "requires CANDIDE_MANAGEMENT_KEY and CANDIDE_GAS_POLICY_TEST_POLICY_ID"
+        : false,
+  },
+  async () => {
+    const url = `${baseUrl}/v1/gas-policies/${encodeURIComponent(testPolicyId)}`;
+    const headers = {
+      Authorization: `Bearer ${managementKey}`,
+      "Content-Type": "application/json",
+    };
+
+    const currentResponse = await fetch(url, { headers });
+    assert.equal(
+      currentResponse.status,
+      200,
+      `failed to read test policy: ${await currentResponse.text()}`,
+    );
+    const currentPolicy = await currentResponse.json();
+    assert.equal(
+      currentPolicy.general.enabled,
+      false,
+      "integration test policy must be disabled before replacing transactions",
+    );
+
+    const originalTransactions = currentPolicy.transactions.map(
+      ({ to, abi, selector, parameters }) => ({ to, abi, selector, parameters }),
+    );
+
+    try {
+      const response = await fetch(`${url}/transactions`, {
+        method: "PUT",
+        headers,
+        body: JSON.stringify(replaceTransactionsBody()),
+      });
+      const responseBody = await response.text();
+      assert.equal(
+        response.status,
+        200,
+        `published PUT example was rejected: ${responseBody}`,
+      );
+    } finally {
+      const restoreResponse = await fetch(`${url}/transactions`, {
+        method: "PUT",
+        headers,
+        body: JSON.stringify({ transactions: originalTransactions }),
+      });
+      const restoreBody = await restoreResponse.text();
+      assert.equal(
+        restoreResponse.status,
+        200,
+        `failed to restore test policy transactions: ${restoreBody}`,
+      );
+    }
+  },
+);

--- a/static/openapi/platform-api.yaml
+++ b/static/openapi/platform-api.yaml
@@ -596,7 +596,7 @@ components:
           description: "4-byte function selector."
         abi:
           type: string
-          description: "JSON ABI fragment."
+          description: "JSON-stringified ABI array containing the complete function fragment."
         parameters:
           type: array
           description: "Constraints on the call arguments."
@@ -615,7 +615,7 @@ components:
           enum: ["$eq", "$gt", "$gte", "$lt", "$lte", "$startsWith"]
         value:
           type: string
-          description: "Value the argument is compared against."
+          description: 'Value the argument is compared against. uint and bytes values must be "0x"-prefixed hexadecimal strings; booleans must be "true" or "false".'
 
     Billing:
       type: object
@@ -778,7 +778,7 @@ components:
           description: 'Target contract address, or the "${userop.sender}" literal.'
         abi:
           type: string
-          description: "JSON ABI fragment containing the function."
+          description: "JSON-stringified ABI array containing the complete function fragment."
         selector:
           type: string
           description: "4-byte function selector, 8 hex characters."


### PR DESCRIPTION
## Summary

- serialize documented transaction ABIs as JSON arrays with complete function fragments
- encode `uint` constraint examples as `0x`-prefixed hexadecimal strings and document the value rules
- align the Gas Policy guide and OpenAPI descriptions with the Platform API validator
- add a build-time static regression for the published PUT payload
- add an opt-in authenticated integration test that expects HTTP 200 and restores a dedicated disabled policy's original transactions

## Root cause

The published examples encoded a single ABI object and decimal `uint` constraint values. The Platform API's ABI parser expects an array, while the transaction validator requires `uint` and `bytes` values to use `0x`-prefixed hexadecimal encoding.

## Impact

Developers can copy the PUT and POST transaction examples without receiving the reported HTTP 422 validation errors. Future documentation builds verify the published PUT body does not regress.

## Validation

- `npm run test:gas-policy-examples`
- `npm run test:gas-policy-api-integration` (skipped without the dedicated test-policy credentials)
- `npm run build`
- JavaScript syntax checks
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that transaction ABI values must be JSON-stringified arrays containing complete function definitions.
  - Documented `0x`-prefixed hexadecimal formatting for `uint` and `bytes` constraint values, plus accepted boolean formats.
  - Updated gas policy examples and API schema descriptions to reflect these formats.

- **Tests**
  - Added validation for documented gas policy examples and API integration behavior, including transaction updates and restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->