### PR TITLE
docs: shift navigation emphasis to Forwarding Address

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -212,9 +212,9 @@ const config = {
       },
       image: 'img/posters/atelier-meta.png',
       announcementBar: {
-        id: 'platform-api-launch',
+        id: 'forwarding-address-launch',
         content:
-          'Create gas policies programmatically with the new Platform API. <a href="/platform/overview/">Read the docs</a>',
+          'Let users deposit from any supported chain into one address. <a href="/forwarding-address/overview/">Read the docs</a>',
         backgroundColor: '#fce7f0',
         textColor: '#1a1a1a',
         isCloseable: true,
@@ -252,6 +252,7 @@ const config = {
             to: '/forwarding-address/overview',
             position: 'left',
             label: 'Forwarding Address',
+            className: 'navbar-badge-new',
           },
           {
             to: '/wallet/api/supported-networks',

--- a/sidebars.js
+++ b/sidebars.js
@@ -59,7 +59,8 @@ const sidebars = {
         {
           type: "doc",
           id: "platform/gas-policy-api",
-          label: "Gas Policy API"
+          label: "Gas Policy API",
+          className: "sidebar-badge-new"
         },
       ],
     },
@@ -287,7 +288,8 @@ const sidebars = {
         {
           type: "doc",
           id: "wallet/solana-paymaster/rpc-methods",
-          label: "Solana RPC Methods"
+          label: "Solana RPC Methods",
+          className: "sidebar-badge-new"
         },
         {
           type: "doc",
@@ -489,8 +491,7 @@ const sidebars = {
         {
           type: "category",
           label: "Pay Gas in Tokens",
-          className: "sidebar-badge-new",
-          collapsed: true,
+          collapsed: false,
           items: [
             {
               type: "doc",
@@ -500,7 +501,8 @@ const sidebars = {
             {
               type: "doc",
               id: "wallet/guides/pay-gas-in-usdt-solana",
-              label: "Solana"
+              label: "Solana",
+              className: "sidebar-badge-new"
             },
           ],
         },
@@ -517,7 +519,6 @@ const sidebars = {
         {
           type: "category",
           label: "Chain Abstraction",
-          className: "sidebar-badge-new",
           collapsed: true,
           items: [
             {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -165,6 +165,23 @@ html[data-theme='dark'] ::-webkit-scrollbar-thumb:hover {
   letter-spacing: 0.05em;
 }
 
+/* Navbar "NEW" badge */
+.navbar-badge-new::after {
+  content: "NEW";
+  margin-left: 0.3rem;
+  vertical-align: super;
+  font-size: 0.5rem;
+  font-weight: 600;
+  color: #E70073;
+  letter-spacing: 0.05em;
+}
+
+/* Mobile navbar menu renders items as .menu__link */
+.navbar-sidebar .navbar-badge-new::after {
+  vertical-align: baseline;
+  font-size: 0.5625rem;
+}
+
 .header-github-link:hover {
   opacity: 0.6;
 }


### PR DESCRIPTION
Rebalances where the docs site spends attention. Everything shipped recently is new, so the badges had stopped signaling anything. Forwarding Address gets the loudest slot; the rest step down a level.

## Announcement bar

Repointed from the Platform API to Forwarding Address:

> Let users deposit from any supported chain into one address. [Read the docs](/forwarding-address/overview/)

Copy leads with the capability rather than the launch, so it reads as useful information on a bar that sits on every page. The `id` changes to `forwarding-address-launch`, otherwise anyone who dismissed `platform-api-launch` would never see the replacement.

## Navbar

`NEW` badge on the Forwarding Address item, via a new `.navbar-badge-new` class. Superscript on desktop, baseline-aligned in the mobile hamburger menu where Docusaurus renders navbar items as `.menu__link`.

## Sidebar badges

| Entry | Change |
|---|---|
| Chain Abstraction | `NEW` removed |
| Pay Gas in Tokens | badge moved off the category onto the Solana guide; section now open by default |
| Gas Policy API | `NEW` added |
| Solana RPC Methods | `NEW` added |

The Platform API keeps its signal through the Gas Policy API badge, which is proportionate to what it is.

## Verification

`yarn build` passes with no errors or broken links.

Worth an eyeball on the deploy preview at mid-desktop widths to confirm the banner does not wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the announcement banner to highlight the Forwarding Address launch.
  * Added “NEW” badges to newly highlighted navigation and documentation entries.
  * Expanded the Pay Gas in Tokens section by default for easier access.
  * Improved badge styling and alignment across desktop and mobile navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->